### PR TITLE
Fixing bug: destroy temp object

### DIFF
--- a/Bedrock.Cube.Data.Copy.pro
+++ b/Bedrock.Cube.Data.Copy.pro
@@ -1219,11 +1219,11 @@ pDestroyTempObj > 0 );
 
   ## Destroy temporary source view.
   IF(
-  nExistingSourceFlag = 0 );
+  nExistingSourceFlag = 1 );
     nRet = ExecuteProcess('Bedrock.Cube.ViewAndSubsets.Delete',
       'pCube', pCube,
       'pView', cTempViewFrom,
-      'pSubset', cTempViewFrom,
+      'pSubset', cTempSubFrom,
       'pMode', pDestroyTempObj,
       'pDebug', pDebug);
   ENDIF;


### PR DESCRIPTION
Process don't destroy temp objects for the source view.
Line: 1222
Condition "nExistingSourceFlag = 0" changed to "nExistingSourceFlag = 1" 
This will destroy object if defined by parameter
Also
Line: 1226
cTempViewFrom changed to cTempSubFrom

This fix unexpected behavior for calling process more than one time where second time and later execution will not copy requested source element.