### PR TITLE
Fixed excessive transaction logging of the attributes cube

### DIFF
--- a/main/}bedrock.hier.create.fromsubset.pro
+++ b/main/}bedrock.hier.create.fromsubset.pro
@@ -225,6 +225,10 @@ DatasourceDimensionSubset = cSubset;
 AttrDelete( pSrcDim, cHierAttr );
 AttrInsert( pSrcDim, '', cHierAttr, 'S' );
 
+# Disable excessive transaction logging of the attributes cube
+sAttrCube = '}ElementAttributes_' | pSrcDim;
+CubeSetLogChanges( sAttrCube, 0 );
+
 nIndex = 1;
 nLimit = HierarchySubsetGetSize( pSrcDim, pSrcHier, pSubset );
 WHILE( nIndex <= nLimit);
@@ -239,6 +243,8 @@ WHILE( nIndex <= nLimit);
     nIndex = nIndex + 1;
 END;
 
+# Re-enable transaction logging of the attributes cube
+CubeSetLogChanges( sAttrCube, 1 );
 
 ### Replicate Attributes ###
 # Note: DType on Attr dim returns "AS", "AN" or "AA" need to strip off leading "A"

--- a/main/}bedrock.hier.create.fromsubset.pro
+++ b/main/}bedrock.hier.create.fromsubset.pro
@@ -225,9 +225,12 @@ DatasourceDimensionSubset = cSubset;
 AttrDelete( pSrcDim, cHierAttr );
 AttrInsert( pSrcDim, '', cHierAttr, 'S' );
 
-# Disable excessive transaction logging of the attributes cube
-sAttrCube = '}ElementAttributes_' | pSrcDim;
-CubeSetLogChanges( sAttrCube, 0 );
+# Disable excessive transaction logging of the attributes cube if it is logged
+sAttrCube = '}ElementAttributes_' | pSourceDim;
+nAttrCubeLogChanges = CubeGetLogChanges(sAttrCube);
+If( nAttrCubeLogChanges = 1 );
+   CubeSetLogChanges( sAttrCube, 0 );
+EndIf;
 
 nIndex = 1;
 nLimit = HierarchySubsetGetSize( pSrcDim, pSrcHier, pSubset );
@@ -243,8 +246,10 @@ WHILE( nIndex <= nLimit);
     nIndex = nIndex + 1;
 END;
 
-# Re-enable transaction logging of the attributes cube
-CubeSetLogChanges( sAttrCube, 1 );
+# Re-enable transaction logging setting of the attributes cube if required
+If( nAttrCubeLogChanges = 1 );
+   CubeSetLogChanges( sAttrCube, 1 );
+EndIf;
 
 ### Replicate Attributes ###
 # Note: DType on Attr dim returns "AS", "AN" or "AA" need to strip off leading "A"

--- a/main/}bedrock.hier.create.fromsubset.pro
+++ b/main/}bedrock.hier.create.fromsubset.pro
@@ -226,7 +226,7 @@ AttrDelete( pSrcDim, cHierAttr );
 AttrInsert( pSrcDim, '', cHierAttr, 'S' );
 
 # Disable excessive transaction logging of the attributes cube if it is logged
-sAttrCube = '}ElementAttributes_' | pSourceDim;
+sAttrCube = '}ElementAttributes_' | pSrcDim;
 nAttrCubeLogChanges = CubeGetLogChanges(sAttrCube);
 If( nAttrCubeLogChanges = 1 );
    CubeSetLogChanges( sAttrCube, 0 );


### PR DESCRIPTION
}bedrock.hier.create.fromsubset is creating a helper attribute in the source dimension, which is by default logged and may result in excessive transaction logging. 

Added a fix to temporarily disable transaction logging if needed.