### PR TITLE
Bedrock Cube Data Clear process update for Cube Logging parameter

### DIFF
--- a/b3shell/Bedrock.Dim.Hierarchy.Unwind.All.pro
+++ b/b3shell/Bedrock.Dim.Hierarchy.Unwind.All.pro
@@ -4,7 +4,7 @@
 586,"}Cubes"
 585,"}Cubes"
 564,
-565,"vX_fwSWUsa]vzJX\EE`>EEa<[3X;iGmgwpM>DLJqyKm8LiB?FrJ9z;UANxPxxV9jNVP0bIDtmtZEm6LFzB[agvY_^ItSveLSz:35Q^klfpu?O^xuBrhD_7rhPfXhHeP;?NmPZ]WpRJu2X5MPjxa=hZ3E0@w\qG[3BvmnnG`8Ghy\hRId<J;brbczMcLI1H?j5oEPJ5tM"
+565,"pldMZhCQNNaZ1gG6aW6qqoQEaqJSC@Kp3x^2\8aWj=8SKaUPOx<ApWOBP08Eh6k:FmkUtMcYr6y5XfpTj5;e``mntNhPv9G9:PqJKic3i68AgXQ9P8H28e^qZckd`[NGwhXbAAmjOKz<y?pT9t14i@^^dWlhW20c>2hnSCCd]aHCLNa6IptVPQ@2Rj:QFikc7vVYBsDt"
 559,1
 928,0
 593,
@@ -18,7 +18,7 @@
 566,0
 567,","
 588,"."
-589,
+589,","
 568,""""
 570,
 571,All
@@ -44,7 +44,7 @@ pDebug,"Debug Mode"
 581,0
 582,0
 603,0
-572,52
+572,53
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -83,8 +83,9 @@ nRet = EXECUTEPROCESS('}bedrock.hier.unwind',
   'pLogOutput', pDebug,
   'pDim', pDimension,
   'pHier', '',
-  'pConsol', '',
-  'pRecursive', 1
+  'pConsol', '*',
+  'pRecursive', 1,
+  'pDelim', '&'
   );
   
   IF(nRet <> 0);

--- a/b3shell/Bedrock.Dim.Hierarchy.Unwind.Consolidation.pro
+++ b/b3shell/Bedrock.Dim.Hierarchy.Unwind.Consolidation.pro
@@ -4,7 +4,7 @@
 586,"}Cubes"
 585,"}Cubes"
 564,
-565,"g31G\<BaKIpt;at0NQi0>>Q]zx:[@Pk83<rkJCp_0sySi\CaotaYCIy8K1@e?2WSISFR:<LaUyU`stQsEr2]TMO\PBGvR7sUusFUL\nwi=5ASOUZF<nL;[h3`sTj?Fqc9icI3KFVF1hnWNI5IQnSuyh4YlYagqN8eyX2p3dsIKrnz?Q>d@q]:PPJFy8oWFs4J\pU3b?V"
+565,"nyc;Ly`uyGiZ45aaS]PGa3Y;QYqBA7w@TV1oeK3HYF_:6;ql0qG25bfMiBPbuBwZHl\W>7PH::lR8RbQkFQdfsShD3MmsobIp8DaEeDnuTc>rqUvwjnRI2k49NSgtmHqn[phu;TPT;YkUum<qF6YzOg1N?4OMgWFI;VRawycv?mZvpVTI>`d<w3KmgIklUxZ:=rj9qnZ"
 559,1
 928,0
 593,
@@ -18,7 +18,7 @@
 566,0
 567,","
 588,"."
-589,
+589,","
 568,""""
 570,
 571,All
@@ -52,7 +52,7 @@ pDebug,"Debug Mode"
 581,0
 582,0
 603,0
-572,65
+572,66
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -108,7 +108,8 @@ nRet = EXECUTEPROCESS('}bedrock.hier.unwind',
   'pDim', pDimension,
   'pHier', '',
   'pConsol', pConsol,
-  'pRecursive', pRecursive
+  'pRecursive', pRecursive,
+  'pDelim', '&'
   );
   
 IF(nRet <> 0);

--- a/main/}bedrock.cube.data.clear.pro
+++ b/main/}bedrock.cube.data.clear.pro
@@ -4,7 +4,7 @@
 586,
 585,
 564,
-565,"sN<>uTKiGFAx_E[QE6BaIgpHrG;7P<5VgRiB2:2v]HvsgNG6eq\YJ6HIqMcuBFqSmXqrrUThsGOI@@ZUng80VMmCJ`lw6jbhT9cTO6O5f7>9qN:ygbp\<8FIxVyf6mSUO5AEteOJuuso;F]BD0m54mWnn@lIc?kGfKo?39huY1oL`L;jlgih4C[mZquY\nk50;LMdo5?"
+565,"p^:xz9=3U^189qx=aP:P[d;Du<[5=wyB=BOOIUlzQ]NkoD4SRuwIU^\:2Am=5]nH<`^HTDmMZMhF?EYUx?s^RQQ;t\YKc0p`RyCIi<HO<rXgedEKJz??UTBkrTrAm`Cq=\[Bw2Q3??aOoXEzWwGSNYoejaj@QrAOyygh<6v1A8EQM]EjfLcK@TvQin1IToJ^9]O[c\>E"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,12
+560,11
 pLogOutput
 pCube
 pView
@@ -37,8 +37,7 @@ pEleStartDelim
 pEleDelim
 pCubeLogging
 pTemp
-pSandbox
-561,12
+561,11
 1
 2
 2
@@ -50,8 +49,7 @@ pSandbox
 2
 1
 1
-2
-590,12
+590,11
 pLogOutput,0
 pCube,""
 pView,""
@@ -63,20 +61,18 @@ pEleStartDelim,"¦"
 pEleDelim,"+"
 pCubeLogging,0
 pTemp,1
-pSandbox,""
-637,12
-pLogOutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
-pCube,"REQUIRED: Cube Name (wildcard * and/or cube1 & cube2 list)"
-pView,"OPTIONAL: View name to be cleared (uses pFilter if pView not specified else clears entire cube)"
-pFilter,"Optional but ignored if view is specified: Year¦ 2006 + 2007 & Scenario¦ Actual + Budget & Organization¦ North America Operations"
-pFilterParallel,"OPTIONAL: Parallelization Filter: Month:Q1+Q2+Q3+Q4 (Blank=run single threaded). Single dimension parallel slices. Will be added to filter single element at a time. Dimension must not be part of filter"
-pParallelThreads,"OPTIONAL: Ignored if pFilterParallel is empty. Maximum number of threads to run when parallel processing is enabled ( if <2 will execute one thread, but parallel filter is still applied )"
-pDimDelim,"OPTIONAL: Delimiter for start of Dimension/Element set  (default value if blank = '&')"
-pEleStartDelim,"OPTIONAL: Delimiter for start of element list  (default value if blank = '¦')"
-pEleDelim,"OPTIONAL: Delimiter between elements (default value if blank = '+')"
-pCubeLogging,"REQUIRED: Cube Logging (0 = No transaction logging, 1 = Logging of transactions)"
-pTemp,"OPTIONAL: Make Views and subsets Temporary (1=Temporary)"
-pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid name will result in process error)"
+637,11
+pLogOutput,"Optional: write parameters and action summary to server message log (Boolean True = 1)"
+pCube,"Required: Cube Name (wildcard * and/or cube1&cube2 list)"
+pView,"Optional: View name to be cleared (uses pFilter if pView not specified else clears entire cube)"
+pFilter,"Optional but ignored if view is specified: Filter: Year: 2006 + 2007 & Scenario: Actual + Budget & Organization: North America Operations"
+pFilterParallel,"Optional: Parallelization Filter: Month:Q1+Q2+Q3+Q4 (Blank=run single threaded). Single dimension parallel slices. Will be added to filter single element at a time. Dimension must not be part of filter"
+pParallelThreads,"Optional: Ignored if pFilterParallel is empty. Maximum number of threads to run when parallel processing is enabled ( if <2 will execute one thread, but parallel filter is still applied )"
+pDimDelim,"Required: Delimiter for Cubes or Dimensions"
+pEleStartDelim,"Required: Delimiter for start of element list"
+pEleDelim,"Required: Delimiter between elements"
+pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
+pTemp,"Optional: Make Views and subsets Temporary (1=Temporary)"
 577,0
 578,0
 579,0
@@ -84,7 +80,7 @@ pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid
 581,0
 582,0
 603,0
-572,454
+572,455
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -92,7 +88,7 @@ If( 1 = 0 );
     	'pCube', '', 'pView', '', 'pFilter', '',
     	'pFilterParallel', '', 'pParallelThreads', 0,
     	'pDimDelim', '&', 'pEleStartDelim', '¦', 'pEleDelim', '+',
-    	'pCubeLogging', 0, 'pTemp', 1, 'pSandbox', pSandbox
+    	'pCubeLogging', 0, 'pTemp', 1
 	);
 EndIf;
 #EndRegion CallThisProcess
@@ -138,7 +134,7 @@ cThisProcName   = GetProcessName();
 cUserName       = TM1User();
 cMsgErrorLevel  = 'ERROR';
 cMsgErrorContent= 'Process:%cThisProcName% ErrorMsg:%sMessage%';
-cLogInfo        = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pView:%pView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pCubeLogging:%pCubeLogging%, pTemp:%pTemp%, pSandbox:%pSandbox%';  
+cLogInfo        = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pView:%pView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pCubeLogging:%pCubeLogging%, pTemp:%pTemp%.' ;  
 cTimeStamp      = TimSt( Now, '\Y\m\d\h\i\s' );
 cRandomInt      = NumberToString( INT( RAND( ) * 1000 ));
 cDefaultView    = Expand( '%cThisProcName%_%cTimeStamp%_%cRandomInt%' );
@@ -178,7 +174,7 @@ If( Trim( pFilter ) @<> '' );
 EndIf;   
 
 # Validate cubelogging parameter
-If( pCubeLogging <> 0 & pCubeLogging <> 1);
+If( pCubeLogging <> 0 & pCubeLogging <> 1 & pCubeLogging <> 2);
   sMessage = 'The cube logging parameter incorrect';
   nErrors = nErrors + 1;
   LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
@@ -207,21 +203,6 @@ If( pParallelThreads >= 1 );
 Else;
   # Single thread mode
   nMaxThreads = 1;
-EndIf;
-
-# Validate Sandbox
-If( TRIM( pSandbox ) @<> '' );
-    If( ServerSandboxExists( pSandbox ) = 0 );
-        SetUseActiveSandboxProperty( 0 );
-        nErrors = nErrors + 1;
-        sMessage = Expand('Sandbox %pSandbox% is invalid for the current user.');
-        LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
-    Else;
-        ServerActiveSandboxSet( pSandbox );
-        SetUseActiveSandboxProperty( 1 );
-    EndIf;
-Else;
-    SetUseActiveSandboxProperty( 0 );
 EndIf;
 
 ### Check for errors before continuing
@@ -301,7 +282,7 @@ While( nCubeDelimiterIndex <> 0 );
             RunProcess( cThisProcName, 'pLogoutput', pLogoutput,
         	    'pCube', pCube, 'pView', pView, 'pFilter', sFilter,
         	    'pFilterParallel', '', 'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim,
-        	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp, 'pSandbox', pSandbox
+        	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp
         	  );
         	  nThreadElCounter = 0;
         	  sFilter = '';
@@ -312,7 +293,7 @@ While( nCubeDelimiterIndex <> 0 );
           RunProcess( cThisProcName, 'pLogoutput', pLogoutput,
       	    'pCube', pCube, 'pView', pView, 'pFilter', sFilter,
       	    'pFilterParallel', '', 'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim,
-      	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp, 'pSandbox', pSandbox
+      	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp
       	  );
     	  ENDIF;
       Else;
@@ -361,22 +342,30 @@ While( nCubeDelimiterIndex <> 0 );
 
             ### Zero Out View ###
             If ( nRes = ProcessExitNormal() );
-              sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
-              CubeSetLogChanges( sCube, pCubeLogging);
+              If ( pCubeLogging <= 1 );
+                sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
+                CubeSetLogChanges( sCube, pCubeLogging);
+              EndIf;
               ViewZeroOut( sCube, cView );
               sMessage = Expand( 'Succeeded in creating the %cView% view in the %sCube% cube and data has been cleared.' );
               LogOutput( 'INFO', Expand( 'Process:%cThisProcName% Message:%sMessage%' ) );
-              CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) );  
+              If ( pCubeLogging <= 1 );
+                CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) );  
+              EndIf;
             Else;
               nErrors = nErrors + 1;
               sMessage = Expand( 'Creating view by %sProc% has failed. Nothing has been cleared in the %sCube% cube.' );
               LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
             EndIf;
           Else;
-            sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
-            CubeSetLogChanges( sCube, pCubeLogging);
+            If ( pCubeLogging <= 1 );
+              sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
+              CubeSetLogChanges( sCube, pCubeLogging);
+            EndIf;
             ViewZeroOut( sCube, cView );
-            CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) ); 
+            If ( pCubeLogging <= 1 );
+              CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) ); 
+            EndIf;
           Endif;
         Endif;
       EndIf;
@@ -453,7 +442,7 @@ While( nCubeDelimiterIndex <> 0 );
             RunProcess( cThisProcName, 'pLogoutput', pLogoutput,
         	    'pCube', pCube, 'pView', pView, 'pFilter', sFilter,
         	    'pFilterParallel', '', 'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim,
-        	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp, 'pSandbox', pSandbox
+        	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp
         	  );
         	  nThreadElCounter = 0;
         	  sFilter = '';
@@ -464,7 +453,7 @@ While( nCubeDelimiterIndex <> 0 );
           RunProcess( cThisProcName, 'pLogoutput', pLogoutput,
       	    'pCube', pCube, 'pView', pView, 'pFilter', sFilter,
       	    'pFilterParallel', '', 'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim,
-      	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp, 'pSandbox', pSandbox
+      	    'pEleDelim', pEleDelim, 'pCubeLogging', pCubeLogging, 'pTemp', pTemp
       	  );
     	  ENDIF;
         Else;
@@ -507,23 +496,31 @@ While( nCubeDelimiterIndex <> 0 );
                   );
   
               ### Zero Out View ###
-              IF ( nRes = ProcessExitNormal() );
-                sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
-                CubeSetLogChanges( sCube, pCubeLogging);
+              If ( nRes = ProcessExitNormal() );
+                If ( pCubeLogging  <= 1 );
+                  sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
+                  CubeSetLogChanges( sCube, pCubeLogging);
+                EndIf;
                 ViewZeroOut( sCube, cView );
                 sMessage = Expand( 'Succeeded in creating the %cView% view in the %sCube% cube and data has been cleared.' );
                 LogOutput( 'INFO', Expand( 'Process:%cThisProcName% Message:%sMessage%' ) );
-                CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) );  
+                If ( pCubeLogging <= 1 );
+                  CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) );  
+                EndIf;
               ELSE;
                 nErrors = nErrors + 1;
                 sMessage = Expand( 'Creating view by %sProc% has failed. Nothing has been cleared in the %sCube% cube.' );
                 LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
               ENDIF;
             Else;
-              sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
-              CubeSetLogChanges( sCube, pCubeLogging);
+              If ( pCubeLogging <= 1 );
+                sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
+                CubeSetLogChanges( sCube, pCubeLogging);
+              EndIf;
               ViewZeroOut( sCube, cView );
-              CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) ); 
+              If ( pCubeLogging <= 1 );
+                CubeSetLogChanges( sCube, IF(sCubeLogging@='YES',1,0) ); 
+              EndIf;
             Endif;
           EndIf;
         EndIf;

--- a/main/}bedrock.hier.sub.create.bymdx.pro
+++ b/main/}bedrock.hier.sub.create.bymdx.pro
@@ -4,7 +4,7 @@
 586,
 585,
 564,
-565,"g[H8sIda9C:G]Y?M3uzUW7\NjdvY]3H2pt:LrWZTRtW2zp4Mmgs8i_K^ZZVnj8v_^HG5?qZUYE0uBfN^TOsS@is8?mNEpIoDLx9gmDnoxBoLuxar0Pu?>;=Ap0m\ZfDXzU3ba`L2]Oqa<[kC3a4AlMAen5VYW_i:hEzJDmadODaW=qTmYumx`aVH1C\:e]y7w=fG>T9V"
+565,"olG7<eZ[xr`m8Kfa@tpMxhAH?8vwAuc_p=QVP]nxovUeLp=@fjQ]5iyc2SM;<TQDNuOTYPo:yGoJgrxhLXOT3cjgJKcjdHrMJwzi1^sIwfSKF_B3QxqeE_KdHb7mE]a?kGNHdTnDslG7\YeB?c0SHtCbzpcuDm\\M2LP?U\s4YWb;mpbnpJKUSL]<b1gf17fJ\6EE^`J"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,7
+560,8
 pLogOutput
 pDim
 pHier
@@ -33,7 +33,8 @@ pSub
 pMDXExpr
 pConvertToStatic
 pTemp
-561,7
+pAlias
+561,8
 1
 2
 2
@@ -41,7 +42,8 @@ pTemp
 2
 1
 1
-590,7
+2
+590,8
 pLogOutput,0
 pDim,""
 pHier,""
@@ -49,14 +51,16 @@ pSub,""
 pMDXExpr,""
 pConvertToStatic,1
 pTemp,1
-637,7
-pLogOutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
-pDim,"REQUIRED: Dimension name"
-pHier,"OPTIONAL: Hierarchy name (default if blank = same named hierarchy)"
-pSub,"REQUIRED: Subset name"
-pMDXExpr,"REQUIRED: Valid MDX Expression for Specified Dimension"
-pConvertToStatic,"OPTIONAL: Bolean: 1 = True (convert to static subset)"
-pTemp,"OPTIONAL: Use temporary objects? (Boolean 1=True)"
+pAlias,""
+637,8
+pLogOutput,"Optional: write parameters and action summary to server message log (Boolean True = 1)"
+pDim,"Required: Dimension name"
+pHier,"Optional: Hierarchy name (default if blank = same named hierarchy)"
+pSub,"Required: Subset name"
+pMDXExpr,"Required: Valid MDX Expression for Specified Dimension"
+pConvertToStatic,"Optional: Bolean: 1 = True (convert to static subset)"
+pTemp,"Optional: Use temporary objects? (Boolean 1=True)"
+pAlias,"Optional: Set Alias for Subset"
 577,0
 578,0
 579,0
@@ -64,7 +68,7 @@ pTemp,"OPTIONAL: Use temporary objects? (Boolean 1=True)"
 581,0
 582,0
 603,0
-572,137
+572,147
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -200,6 +204,16 @@ If( nErrors = 0 );
     EndIf;
   EndIf;
 EndIf;
+
+### Set Alias ###
+If(pAlias @<> '' );
+  If ( pDim @= sHier );
+    SubsetAliasSet( pDim, pSub, pAlias);
+  Else;
+    SubsetAliasSet( pDim | ':' | sHier, pSub, pAlias);
+  EndIf;
+EndIf;
+
 
 ### End Prolog ###
 573,5

--- a/main/}bedrock.server.executecommand.pro
+++ b/main/}bedrock.server.executecommand.pro
@@ -130,7 +130,7 @@ If( nErrors > 0 );
     LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
     sProcessReturnCode = Expand( '%sProcessReturnCode% Process:%cThisProcName% completed with errors. Check tm1server.log for details.' );
 Else;
-    sProcessAction = Expand( 'Process:%cThisProcName% successfully saved all cube data.' );
+    sProcessAction = Expand( 'Process:%cThisProcName% completed successfully.' );
     sProcessReturnCode = Expand( '%sProcessReturnCode% %sProcessAction%' );
     nProcessReturnCode = 1;
     If( pLogoutput = 1 );

--- a/main/}bedrock.server.executecommand.pro
+++ b/main/}bedrock.server.executecommand.pro
@@ -1,0 +1,172 @@
+﻿601,100
+602,"}bedrock.server.executecommand"
+562,"NULL"
+586,
+585,
+564,
+565,"c6ra[C[7?MRZGEd4Vj8iW<bLezX3G;syGaB:Sf0R1gMIzkNX0>6jhYCZzGu=F6_VXaS3geIQPIpyx6J:V[jfDQgSFAG8iQts]3x9DVFqhJu4emK64:eRYT@aakRBkVloBi;bGY11r_B>gze>foyX0_bp>^DJ69mEKS<0aCEznZ>SIE0<Am=UX]XUlOw4p6mBD@XElDmH"
+559,1
+928,0
+593,
+594,
+595,
+597,
+598,
+596,
+800,
+801,
+566,0
+567,","
+588,"."
+589,","
+568,""""
+570,
+571,
+569,0
+592,0
+599,1000
+560,3
+pLogOutput
+pCommand
+pWait
+561,3
+1
+2
+2
+590,3
+pLogOutput,0
+pCommand,""
+pWait,"0"
+637,3
+pLogOutput,"Optional: write parameters and action summary to server message log (Boolean True = 1)"
+pCommand,"The full command line string to execute"
+pWait,"Wait for command to finish 0=false 1=true"
+577,0
+578,0
+579,0
+580,0
+581,0
+582,0
+603,0
+572,47
+#****Begin: Generated Statements***
+#****End: Generated Statements****
+
+################################################################################################# 
+##~~Join the bedrock TM1 community on GitHub https://github.com/cubewise-code/bedrock Ver 4.0~~##
+################################################################################################# 
+
+#Region @DOC
+# Description:
+# This process will run the TI ExecuteCommand function.
+
+# Use case: Intended for production.
+# 1/ To run an executeCommand function from any part of the model, including RushTI or third party system without direct access to TI Editor.
+# 2/ To remove the requirement of creating a one off process to use this function
+
+#EndRegion @DOC
+
+### Global Variables
+StringGlobalVariable('sProcessReturnCode');
+NumericGlobalVariable('nProcessReturnCode');
+nProcessReturnCode= 0;
+
+### Constants ###
+cThisProcName = GetProcessName();
+cUserName = TM1User();
+cMsgErrorLevel = 'ERROR';
+cMsgErrorContent = 'User:%cUserName% Process:%cThisProcName% ErrorMsg:%sMessage%';
+
+## LogOutput parameters
+If( pLogOutput = 1 );
+  sLogInfo = Expand('Process:%cThisProcName% run with parameters: pCommand: %pCommand%, pWait: %pWait%'); 
+  LogOutput ( 'INFO', sLogInfo );
+  nStart = Now();
+EndIf;
+
+### Validate Parameters ###
+nErrors = 0;
+If ( pCommand @= '' );
+  sMessage = 'parameter pCommand is blank';
+  LogOutput ( 'ERROR', sMessage );
+  ProcessQuit;
+EndIf;
+
+### ExecuteCommand ###
+nWait = StringToNumber ( pWait );
+ExecuteCommand ( pCommand, nWait );
+
+573,2
+#****Begin: Generated Statements***
+#****End: Generated Statements****
+574,2
+#****Begin: Generated Statements***
+#****End: Generated Statements****
+575,27
+#****Begin: Generated Statements***
+#****End: Generated Statements****
+
+### LogOutput ###
+
+If( pLogOutput = 1 );
+    sSec     = NumberToStringEx( 86400*(Now() - nStart),'#,##0.0', '.', ',' );
+    sLogInfo = Expand('Process:%cThisProcName% completed. Elapsed time %sSec% seconds.'); 
+    LogOutput( 'INFO', sLogInfo );
+EndIf;
+
+### Return code & final error message handling
+If( nErrors > 0 );
+    sMessage = 'the process incurred at least 1 error. Please see above lines in this file for more details.';
+    nProcessReturnCode = 0;
+    LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
+    sProcessReturnCode = Expand( '%sProcessReturnCode% Process:%cThisProcName% completed with errors. Check tm1server.log for details.' );
+Else;
+    sProcessAction = Expand( 'Process:%cThisProcName% successfully saved all cube data.' );
+    sProcessReturnCode = Expand( '%sProcessReturnCode% %sProcessAction%' );
+    nProcessReturnCode = 1;
+    If( pLogoutput = 1 );
+        LogOutput('INFO', Expand( sProcessAction ) );   
+    EndIf;
+EndIf;
+
+### End Epilog ###
+576,
+930,0
+638,1
+804,0
+1217,0
+900,
+901,
+902,
+938,0
+937,
+936,
+935,
+934,
+932,0
+933,0
+903,
+906,
+929,
+907,
+908,
+904,0
+905,0
+909,0
+911,
+912,
+913,
+914,
+915,
+916,
+917,0
+918,1
+919,0
+920,50000
+921,""
+922,""
+923,0
+924,""
+925,""
+926,""
+927,""

--- a/main/}bedrock.server.executecommand.pro
+++ b/main/}bedrock.server.executecommand.pro
@@ -94,6 +94,15 @@ EndIf;
 
 ### ExecuteCommand ###
 nWait = StringToNumber ( pWait );
+
+# Check if the pCommand parameter is enclosed in quotes and add if not
+sSubst = Subst ( pCommand, 1, 1 );
+If ( Subst ( pCommand, 1, 1 ) @<> '"' );
+  sCommand = Expand ( '"%pCommand%"' );
+Else;
+  sCommand = pCommand;
+EndIf;
+
 ExecuteCommand ( pCommand, nWait );
 
 573,2


### PR DESCRIPTION
Adding new parameter for pCubeLogging to accept a new parameter value of 2 to instruct the process to not take any action on cube logging, this was found following an issue where this parameter stops multi-threaded processes from running.