### PR TITLE
Updated processes with pCubeLogging parameter

### DIFF
--- a/main/}bedrock.cube.clone.pro
+++ b/main/}bedrock.cube.clone.pro
@@ -4,7 +4,7 @@
 586,"Bedrock Test"
 585,"Bedrock Test"
 564,
-565,"cY8yQlU[?Xx<I@ULBU47dVVcitve9FX?FoD2u8RiyE[[\ni[@xp;`hCGGSugdY|vGOaxZvuig1FZN[9aS\tksau_Y7HBZv]f0GK1]?NxDjxo4LclXIfSyu8Gk2VZ\2Z6QrEIblqU:L<S`ONaGFP6mRduxoos2SW3]LbmrF}ZvlMelTlH6ddxZMrniBt?CJf[@B\U1Gu`"
+565,"biygQyNLrIp^^4n0F3]@@55wO3r^lS=264Al_0E>J25JIkinTruTO_y5=PuGeVr6<L^vj7S:XGJzA]iQjHCwy6]zLcG2TOTQ>7g<M2ZQaGhhvnolX5g;9\M0R7mTW2L_RyeKBx3Sdr1ZPX6mG?l0m9mQZ[Drf=vKSHiMDO~:4s@amTMJ1NffwDBk=KVb\EVW0WBN@a5o"
 559,1
 928,0
 593,
@@ -76,7 +76,7 @@ pEleStartDelim,"OPTIONAL: Delimiter for start of element list  (default value if
 pEleDelim,"OPTIONAL: Delimiter between elements (default value if blank = '+')"
 pSuppressRules,"REQUIRED: Skip rule values? (1=skip)"
 pTemp,"REQUIRED: Delete temporary view and Subset ( 0 = Retain View and Subsets 1 = Delete View and Subsets 2 = Delete View only )"
-pCubeLogging,"REQUIRED: Cube Logging (0 = No transaction logging, 1 = Logging of transactions)"
+pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
 577,28
 v1
 v2

--- a/main/}bedrock.cube.data.copy.intercube.pro
+++ b/main/}bedrock.cube.data.copy.intercube.pro
@@ -4,7 +4,7 @@
 586,"Bedrock Source Cube"
 585,"Bedrock Source Cube"
 564,
-565,"c6Ia;xWP=5U_7];PbYAYzNKrI^?m6qCohSN>X1JvMWIS:?OEhfUE6`<nuPTI;Zino>f>0KKfGWz21VUs0o_5;rxwEGUbZSAdSWd0FRtxvoO57_fPyKyk[GkRH5z=UOljEmsSlEetp7fCshm[d47KgwNjS4kR>e[wP:`^vJs592VZlF=CEpT>U9L0p:OwCvDF_yj;9tDj"
+565,"cr;aJYQ^HeXoNZj\3g[L\m9lG>QD6ukw1vY@=6FVmVe@PaqHY<;`^L6gjFzUQhP3OtdYHhZ^SR<5JTWdh]^>V:xXV3D\Pm18HCxQ[vGVszLTfKi33@YI5JeX;9=msW`nKJedJZ@<iu:hPCuuw;42T=l88DY\kIm`^?f`ql3iBqqex3TvZON0PAawDT30>NQI0ylF1U2["
 559,1
 928,0
 593,
@@ -102,7 +102,7 @@ pDimDelim,"OPTIONAL. Delimiter for start of Dimension/Element set"
 pEleStartDelim,"OPTIONAL: Delimiter for start of element list"
 pEleDelim,"OPTIONAL: Delimiter between elements"
 pTemp,"OPTIONAL: Delete temporary view and Subset ( 0 = Retain View and Subsets 1 = Delete View and Subsets 2 = Delete View only )"
-pCubeLogging,"OPTIONAL: Cube Logging (0 = No transaction logging, 1 = Logging of transactions)"
+pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
 pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid name will result in process error)"
 pThreadMode,"DO NOT USE: Internal parameter only, please don't use"
 577,29
@@ -286,7 +286,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,1100
+572,1101
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1324,8 +1324,7 @@ Else;
           ProcessBreak;
       ENDIF;
   
-      sProc = '}bedrock.cube.data.clear';
-      nRet = ExecuteProcess( sProc,
+      nRet = ExecuteProcess( '}bedrock.cube.data.clear',
           'pLogOutput', pLogOutput,
           'pCube', pTgtCube,
           'pView', sTargetView,
@@ -1378,8 +1377,10 @@ Else;
   
   
   ### Assign Datasource ###
-  sCubeLogging = CellGetS('}CubeProperties', pTgtCube, 'LOGGING' );
-  CubeSetLogChanges( pTgtCube, pCubeLogging);
+  If ( pCubeLogging <= 1 );
+    sCubeLogging = CellGetS('}CubeProperties', pTgtCube, 'LOGGING' );
+    CubeSetLogChanges( pTgtCube, pCubeLogging);
+  EndIf;
   
   ### Assign Datasource ###
   DataSourceType          = 'VIEW';
@@ -1731,7 +1732,7 @@ sV28=IF(nMappedDim28=1, Expand('%'|sMappedV28|'%'),V28);
 
 
 
-575,35
+575,41
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -1740,14 +1741,20 @@ sV28=IF(nMappedDim28=1, Expand('%'|sMappedV28|'%'),V28);
 If( pThreadMode <> 0 );
   ## Zero Source
   If( pZeroSource = 1 & nErrors = 0  );
-    sCubeLogging = CellGetS('}CubeProperties', pSrcCube, 'LOGGING' );
-    CubeSetLogChanges( pSrcCube, pCubeLogging);
+    If ( pCubeLogging <= 1 );
+      sCubeLogging = CellGetS('}CubeProperties', pSrcCube, 'LOGGING' );
+      CubeSetLogChanges( pSrcCube, pCubeLogging);
+    EndIf;
     ViewZeroOut( pSrcCube, sView );
-    CubeSetLogChanges( pSrcCube, IF(sCubeLogging@='YES',1,0) );
+    If ( pCubeLogging <= 1 );
+      CubeSetLogChanges( pSrcCube, IF(sCubeLogging@='YES',1,0) );
+    EndIf;
   EndIf;
 Else;
   ## Switch back logging on Tgt Cube
-  CubeSetLogChanges( pTgtCube, IF(sCubeLogging@='YES',1,0) );
+  If ( pCubeLogging <= 1 );
+    CubeSetLogChanges( pTgtCube, IF(sCubeLogging@='YES',1,0) );
+  EndIf;
 EndIf;    
 
 ### Return code & final error message handling

--- a/main/}bedrock.cube.data.copy.pro
+++ b/main/}bedrock.cube.data.copy.pro
@@ -4,7 +4,7 @@
 586,"zzSYS 50 Dim Cube"
 585,"zzSYS 50 Dim Cube"
 564,
-565,"kZgYXnSpZ7SaY1>3]\pcDyhqMJqwOU9\oC@N1hwPc\t?r=3w]2b<z35?cNzwXCK?3kbqDxqe>0]dWeq[gsLZ^IK`m[\jH`rdwb?Isy:CJhA8LCSi1GcVI?Tht7IvYexS:Io8xaX=XuxHN_ewgPjbXi=oekjyzH2kOAQ@vtSWul9?zuod>D98AK8Pg5c_BVPxTT7hK5Xy"
+565,"kh=U=NIEf]EakS0iox=mRolTyJ_1rbuQb7pW^>u46TPP4Rk8u0W;TUFkGFh]myVMsRI<JpDu>f6ah5B]^GHXu5_UwzV:HRZJ=VdKCfei:yF@al_Uw6lrhq:P8_1WZVgM6oi7<B=N]K4p2\yTgnWU_BALQ8htQlLsRRDQ=zwTpz\ksG4;9<uELSX]^qOA:0Sop4QMLdFT"
 559,1
 928,0
 593,
@@ -114,7 +114,7 @@ pCumulate,"OPTIONAL: 1 = Add source to existing value in target (if zero out tar
 pZeroTarget,"OPTIONAL: Zero out Target Element PRIOR to Copy? (Boolean 1=True)"
 pZeroSource,"OPTIONAL: Zero out Source Element AFTER Copy? (Boolean 1=True)"
 pTemp,"OPTIONAL: Delete temporary view and Subset ( 0 = Retain View and Subsets 1 = Delete View and Subsets 2 = Delete View only )"
-pCubeLogging,"OPTIONAL: Cube Logging (0 = No transaction logging, 1 = Logging of transactions)"
+pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
 pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid name will result in process error)"
 pThreadMode,"DO NOT USE: Internal parameter only, please don't use"
 577,51
@@ -430,7 +430,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=33ColType=827
 603,0
-572,797
+572,799
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1215,8 +1215,10 @@ Else;
         ProcessBreak;
   ENDIF;
   
-  sCubeLogging = CellGetS('}CubeProperties', pCube, 'LOGGING' );
-  CubeSetLogChanges( pCube, pCubeLogging);
+  If ( pCubeLogging <= 1 );
+    sCubeLogging = CellGetS('}CubeProperties', pCube, 'LOGGING' );
+    CubeSetLogChanges( pCube, pCubeLogging);
+  EndIf;
   ### Assign Datasource ###
   DataSourceType          = 'VIEW';
   DatasourceNameForServer = pCube;
@@ -1681,7 +1683,7 @@ ElseIf( nDimensionCount = 27 );
 
 
 ### End Data ###
-575,53
+575,55
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -1717,7 +1719,9 @@ If( nThreadMode <> 0 );
   ENDIF;
 
 Else;
-  CubeSetLogChanges( pCube, IF(sCubeLogging@='YES',1,0) );
+  If ( pCubeLogging <= 1 );
+    CubeSetLogChanges( pCube, IF(sCubeLogging@='YES',1,0) );
+  EndIf;
 EndIf;
 
 ### Return code & final error message handling

--- a/main/}bedrock.cube.data.export.pro
+++ b/main/}bedrock.cube.data.export.pro
@@ -4,7 +4,7 @@
 586,"}APQ Staging TempSource"
 585,"}APQ Staging TempSource"
 564,
-565,"iHz_xghYQaEGmVlLkBxncH64LZV7OD40alRW]F1<CskY;[MLfkxNkjt[6o]DSa]FVC9GY=?G9NtYnOt0k9dXPhtNun:4Ce`kFLw9C9CkdRqkE<bssJD9pM0VJn0<2zE@myibw\HAZm1l0RZWVMRHAI4G^Yk=wflYDoN_8\ndjHSVhSJGzV3Dh:0_ER[KvbARW?Kb;YeD"
+565,"qDb5?gpFTJg;2M83hadav3=]<l<a9XPZBWoFI3RnR9fDtfhJejpREL_A7a^5IRNxyhhnNnwb0[3FSssKUQzMsPZ=:ef?DgwxQyqt_^]H]sAjVK<[iIV9nJKBLcCzrl<k<LRxF\oQdQ<PhTLS6nXeWXd4<9K`=ggEC]5H`;trTmDvhRJY6So4=eYu[<=r4M\Szo>HD9m7"
 559,1
 928,0
 593,
@@ -105,7 +105,7 @@ pSuppressZero,"OPTIONAL: Suppress Zero Values (1=Suppress)"
 pSuppressConsol,"OPTIONAL: Suppress Consolidated Values? (1=Suppress)"
 pSuppressRules,"OPTIONAL: Suppress Rule Values? (1=Suppress)"
 pZeroSource,"OPTIONAL: Zero Out view AFTER Copy? (Boolean 1=True)"
-pCubeLogging,"OPTIONAL: Cube Logging (0 = No transaction logging, 1 = Logging of transactions)"
+pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
 pTemp,"OPTIONAL: Retain temporary view and Subset ( 0 = retain View and Subsets 1 = use temp objects)"
 pFilePath,"OPTIONAL: Export Directory (will default to error file path)"
 pFileName,"OPTIONAL: Export Filename (If Left Blank Defaults to cube_export.csv)"
@@ -1127,7 +1127,7 @@ ENDIF;
 AsciiOutput( cExportFile, Expand(sRow) );
 
 ### End Data ###
-575,34
+575,38
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -1138,10 +1138,14 @@ AsciiOutput( cExportFile, Expand(sRow) );
 
 ### Delete source data ###
 If( pZeroSource = 1 & nErrors = 0 & nParallelRun = 0 );
-    sCubeLogging = CellGetS('}CubeProperties', pCube, 'LOGGING' );
-    CubeSetLogChanges( pCube, pCubeLogging);
+    If ( pCubeLogging <= 1 );
+      sCubeLogging = CellGetS('}CubeProperties', pCube, 'LOGGING' );
+      CubeSetLogChanges( pCube, pCubeLogging);
+    EndIf;
     ViewZeroOut( pCube, cView );
-    CubeSetLogChanges( pCube, IF(sCubeLogging@='YES',1,0) ); 
+    If ( pCubeLogging <= 1 );
+      CubeSetLogChanges( pCube, IF(sCubeLogging@='YES',1,0) ); 
+    EndIf;
 EndIf;
 
 ### Return code & final error message handling

--- a/main/}bedrock.cube.data.import.pro
+++ b/main/}bedrock.cube.data.import.pro
@@ -4,7 +4,7 @@
 586,"C:\TM1\Bedrock\Data\Bedrock.Z.Cube.Placeholder.csv"
 585,"C:\TM1\Bedrock\Data\Bedrock.Z.Cube.Placeholder.csv"
 564,
-565,"fWcRFQaFHA?K5ZvoHCZKeB9Q_DiWGF4Xu7P^gMfCNGyBQ[1^_mgbLYK`Gdx6NvsHrUU_=yukS5l<Dhvk>\NV`C1dJxJOFEAzkCV0mBwvAFKLPG;Mr0xGP08KObQniF_xkFbDo?@<c:V<:348aj0?^GUENKUCgzQi2el8Ycs]l>z7Q_4LTgcv9F8Aa?kf]UVMvmkj5dv^"
+565,"om6znjN6E>J:zQ3aB<[dK<>MW`Y4<cje=IJAktz0NoaX6UNA?s5yU]m>X5\2_^;FH6awGErRSBWaj0nYoYr0a4?\RqV`?<<Qlqc;B[TXLRjtfKwNsGNCOJ@4LW;wPaS<M064cgYq:w[pA[y9UAZ;LcXW8T=Ck@g`7:oH8_CGlVx`Yj`Eze;Z_`dgqJaA9i\GkyUIycRq"
 559,1
 928,0
 593,
@@ -79,7 +79,7 @@ pTitleRows,"REQUIRED: Number of Title Rows to Skip"
 pDelim,"REQUIRED: AsciiOutput delimiter character (Default=comma, exactly 3 digits = ASCII code)"
 pQuote,"REQUIRED: Quote (Accepts empty quote, exactly 3 digits = ASCII code)"
 pCumulate,"REQUIRED: Accumulate Amounts (0 = Overwrite values, 1 = Accumulate values)"
-pCubeLogging,"REQUIRED: Cube Logging (0 = No transaction logging, 1 = Logging of transactions)"
+pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
 pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid name will result in process error)"
 577,30
 v1
@@ -268,7 +268,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,325
+572,327
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -582,8 +582,10 @@ sDim26 = TabDim( pCube, 26 );
 sDim27 = TabDim( pCube, 27 );
 
 #CubeLogging
-sCubeLogging = CellGetS('}CubeProperties', pCube, 'LOGGING' );
-CubeSetLogChanges( pCube, pCubeLogging);
+If ( pCubeLogging <= 1 );
+  sCubeLogging = CellGetS('}CubeProperties', pCube, 'LOGGING' );
+  CubeSetLogChanges( pCube, pCubeLogging);
+EndIf;
 
 ### Assign Datasource ###
 DataSourceType                  = 'CHARACTERDELIMITED';
@@ -1079,7 +1081,7 @@ ElseIf( nDimensionCount = 27 );
 ## Increase Record count
 nRecordPostedCount = nRecordPostedCount + 1;
 ### End Data ###
-575,36
+575,38
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -1089,7 +1091,9 @@ nRecordPostedCount = nRecordPostedCount + 1;
 ################################################################################################# 
 
 #Cube Logging
-CubeSetLogChanges( pCube, IF(sCubeLogging@='YES',1,0) );
+If ( pCubeLogging <= 1 );
+  CubeSetLogChanges( pCube, IF(sCubeLogging@='YES',1,0) );
+EndIf;
     
 ### If errors occurred terminate process with a major error status ###
 If( nErrors > 0 );


### PR DESCRIPTION
Updated processes with pCubeLogging parameter to include an additional option of 2 to ignore cube logging and take no action, this was found to cause issues of locking when using multi-threading processes.