### PR TITLE
Consistent usage of the variable nRet

### DIFF
--- a/main/}bedrock.cube.data.clear.pro
+++ b/main/}bedrock.cube.data.clear.pro
@@ -345,7 +345,7 @@ While( nCubeDelimiterIndex <> 0 );
 
             ### Create View using filter (temp view, therefore no need to destroy) ###
             sProc = '}bedrock.cube.view.create';
-            nRes = ExecuteProcess( sProc,
+            nRet = ExecuteProcess( sProc,
                     'pLogOutput', pLogOutput,
                     'pCube', sCube,
                     'pView', cView,
@@ -360,7 +360,7 @@ While( nCubeDelimiterIndex <> 0 );
                     );
 
             ### Zero Out View ###
-            If ( nRes = ProcessExitNormal() );
+            If ( nRet = ProcessExitNormal() );
               If ( pCubeLogging <= 1 );
                 sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
                 CubeSetLogChanges( sCube, pCubeLogging);
@@ -500,7 +500,7 @@ While( nCubeDelimiterIndex <> 0 );
   
               ### Create View using filter (temp view, therefore no need to destroy) ###
               sProc = '}bedrock.cube.view.create';
-              nRes = ExecuteProcess( sProc,
+              nRet = ExecuteProcess( sProc,
                   'pLogOutput', pLogOutput,
                   'pCube', sCube,
                   'pView', cView,
@@ -515,7 +515,7 @@ While( nCubeDelimiterIndex <> 0 );
                   );
   
               ### Zero Out View ###
-              IF ( nRes = ProcessExitNormal() );
+              IF ( nRet = ProcessExitNormal() );
                 If ( pCubeLogging <= 1 );
                   sCubeLogging = CellGetS('}CubeProperties', sCube, 'LOGGING' );
                   CubeSetLogChanges( sCube, pCubeLogging);


### PR DESCRIPTION
Consistent usage of the variable nRet for the outcome of ExecuteProcess calls. In the current process, nRes is used (4 times). In other processes, nReturncode is used. This should be harmonized to nRet.