### PR TITLE
Update }bedrock.cube.data.copy.pro - pSuppressZero

### DIFF
--- a/main/}bedrock.cube.data.copy.pro
+++ b/main/}bedrock.cube.data.copy.pro
@@ -4,7 +4,7 @@
 586,"zzSYS 50 Dim Cube"
 585,"zzSYS 50 Dim Cube"
 564,
-565,"qT<RB=Mu[>la4Wou>yjB3xfy`K[Jp3J8aC4e[zG_I2qRG`y:`[A<=f8`\4Fq9uO;FXD4Q^yQ]iiAPwSYj4`2KmN@n5~JIwmDPn8<]M__FM>V\IqWH9YEiQy1Xh1aFMzRB@;U79^IILAvfLpUt57:=p>NDE_kMAEnpt4hKKj8AY3EH:^52ixJ=E]E5xvgbr@bBfL0;g1u"
+565,"wxNG6t[UirThsZl:yBDM]hDy1bB:IJ@4QwI_4Pa]tG?Lya92@mpR3wbuz3Fa[cBKgWI=Qq[K77haJq3YuY]Ww_hwkHqJ=C[489R8mk75T[\1AJyWHKkJieeUAZIqOm@64I;SGA>@>NWy6lL_DEL<}7R\CQC`>:Bjhd>Hgy`h1n^LF:Itfgh;AI}_RpAfgy0cB2I6Khzq"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,25
+560,26
 pLogOutput
 pStrictErrorHandling
 pCube
@@ -42,6 +42,7 @@ pEleDelim
 pFactor
 pSuppressConsol
 pSuppressRules
+pSuppressZero
 pCumulate
 pZeroTarget
 pZeroSource
@@ -51,7 +52,7 @@ pSandbox
 pFile
 pSubN
 pThreadMode
-561,25
+561,26
 1
 1
 2
@@ -73,11 +74,12 @@ pThreadMode
 1
 1
 1
+1
 2
 1
 1
 1
-590,25
+590,26
 pLogOutput,0
 pStrictErrorHandling,0
 pCube,""
@@ -94,6 +96,7 @@ pEleDelim,"+"
 pFactor,1
 pSuppressConsol,1
 pSuppressRules,1
+pSuppressZero,1
 pCumulate,0
 pZeroTarget,1
 pZeroSource,0
@@ -103,7 +106,7 @@ pSandbox,""
 pFile,0
 pSubN,0
 pThreadMode,0
-637,25
+637,26
 pLogOutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
 pStrictErrorHandling,"OPTIONAL: On encountering any error, exit with major error status by ProcessQuit after writing to the server message log (Boolean True = 1)"
 pCube,"REQUIRED: Cube"
@@ -120,6 +123,7 @@ pEleDelim,"OPTIONAL: Delimiter between elements (default value if blank = '+')"
 pFactor,"OPTIONAL: Multiply source value by factor (1 keeps the value as is). To modify existing values make the target element the same as the source with pZeroTarget = 0"
 pSuppressConsol,"OPTIONAL: Suppress Consolidated Cells (Skip = 1)"
 pSuppressRules,"OPTIONAL: Suppress Rules (Skip = 1)"
+pSuppressZero,"OPTIONAL: Suppress Zero Cells (Skip = 1)"
 pCumulate,"OPTIONAL: 1 = Add source to existing value in target (if zero out target = 0 False). 0 = Replace target with source."
 pZeroTarget,"OPTIONAL: Zero out Target Element PRIOR to Copy? (Boolean 1=True)"
 pZeroSource,"OPTIONAL: Zero out Source Element AFTER Copy? (Boolean 1=True)"
@@ -452,7 +456,7 @@ If( 1 = 0 );
     	'pFilterParallel', '', 'pParallelThreads', 0,
     	'pEleMapping', '', 'pMappingDelim', '->',
     	'pDimDelim', '&', 'pEleStartDelim', '¦', 'pEleDelim', '+',
-    	'pFactor', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pCumulate', 0,
+    	'pFactor', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressZero', 1, 'pCumulate', 0,
     	'pZeroTarget', 1, 'pZeroSource', 0,
     	'pTemp', 1, 'pCubeLogging', 0, 'pSandbox', '', 'pFile', 0, 'pSubN', 0
     );
@@ -504,7 +508,7 @@ cRandomInt      = NumberToString( INT( RAND( ) * 1000 ));
 cTempSub        = cThisProcName |'_'| cTimeStamp |'_'| cRandomInt;
 cMsgErrorLevel  = 'ERROR';
 cMsgErrorContent= 'Process:%cThisProcName% ErrorMsg:%sMessage%';
-cLogInfo        = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pSrcView:%pSrcView%, pTgtView:%pTgtView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pEleMapping:%pEleMapping%, pMappingDelim:%pMappingDelim%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pFactor:%pFactor%, pSuppressConsol:%pSuppressConsol%, pSuppressRules:%pSuppressRules%, pCumulate:%pCumulate%, pZeroTarget:%pZeroTarget%, pZeroSource:%pZeroSource%, pTemp:%pTemp%, pCubeLogging:%pCubeLogging%, pSandbox:%pSandbox%, pFile:%pFile%.';   
+cLogInfo        = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pSrcView:%pSrcView%, pTgtView:%pTgtView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pEleMapping:%pEleMapping%, pMappingDelim:%pMappingDelim%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pFactor:%pFactor%, pSuppressConsol:%pSuppressConsol%, pSuppressRules:%pSuppressRules%, pSuppressZero:%pSuppressZero%, pCumulate:%pCumulate%, pZeroTarget:%pZeroTarget%, pZeroSource:%pZeroSource%, pTemp:%pTemp%, pCubeLogging:%pCubeLogging%, pSandbox:%pSandbox%, pFile:%pFile%.';   
 cDefaultView    = Expand( '%cThisProcName%_%cTimeStamp%_%cRandomInt%' );
 
 ## LogOutput parameters
@@ -1185,7 +1189,7 @@ If( Scan( pEleStartDelim, pFilterParallel ) > 0 );
       	'pCube', pCube, 'pSrcView', pSrcView, 'pTgtView', pTgtView,
       	'pFilter', sFilter, 'pFilterParallel', '', 'pEleMapping', pEleMapping, 'pMappingDelim', pMappingDelim,
       	'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim, 'pEleDelim', pEleDelim,
-      	'pFactor', pFactor, 'pSuppressConsol', pSuppressConsol, 'pSuppressRules', pSuppressRules, 'pCumulate', pCumulate,
+      	'pFactor', pFactor, 'pSuppressConsol', pSuppressConsol, 'pSuppressRules', pSuppressRules, 'pSuppressZero', pSuppressZero, 'pCumulate', pCumulate,
       	'pZeroTarget', pZeroTarget, 'pZeroSource', pZeroSource, 'pTemp', pTemp, 'pCubeLogging', pCubeLogging, 'pSandbox', pSandbox, 'pFile', pFile, 'pThreadMode', 1
       );
   	  nThreadElCounter = 0;
@@ -1198,7 +1202,7 @@ If( Scan( pEleStartDelim, pFilterParallel ) > 0 );
     	'pCube', pCube, 'pSrcView', pSrcView, 'pTgtView', pTgtView,
     	'pFilter', sFilter, 'pFilterParallel', '', 'pEleMapping', pEleMapping, 'pMappingDelim', pMappingDelim,
     	'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim, 'pEleDelim', pEleDelim,
-    	'pFactor', pFactor, 'pSuppressConsol', pSuppressConsol, 'pSuppressRules', pSuppressRules, 'pCumulate', pCumulate,
+    	'pFactor', pFactor, 'pSuppressConsol', pSuppressConsol, 'pSuppressRules', pSuppressRules, 'pSuppressZero', pSuppressZero, 'pCumulate', pCumulate,
     	'pZeroTarget', pZeroTarget, 'pZeroSource', pZeroSource, 'pTemp', pTemp, 'pCubeLogging', pCubeLogging, 'pSandbox', pSandbox, 'pFile', pFile, 'pThreadMode', 1
     );
   ENDIF;
@@ -1252,7 +1256,7 @@ Else;
       'pCube', pCube,
       'pView', cViewSource,
       'pFilter', sFilter,
-      'pSuppressZero', 1,
+      'pSuppressZero', pSuppressZero,
       'pSuppressConsol', nSuppressConsol,
       'pSuppressRules', pSuppressRules,
       'pDimDelim', pDimDelim,
@@ -1294,7 +1298,7 @@ Else;
        'pDimDelim', pDimDelim,
        'pEleStartDelim', pEleStartDelim,
        'pEleDelim', pEleDelim,
-       'pSuppressZero', 1,
+       'pSuppressZero', pSuppressZero,
        'pSuppressConsol', nSuppressConsol,
        'pSuppressRules', pSuppressRules,
        'pZeroSource', 0,
@@ -1344,13 +1348,11 @@ EndIf;
 ### End Prolog ###
 
 
-573,4
-
+573,3
 #****Begin: Generated Statements***
 #****End: Generated Statements****
 
-574,457
-
+574,456
 #****Begin: Generated Statements***
 #****End: Generated Statements****
 
@@ -1807,8 +1809,7 @@ ElseIf( nDimensionCount = 27 );
 
 
 ### End Data ###
-575,62
-
+575,61
 #****Begin: Generated Statements***
 #****End: Generated Statements****
 
@@ -1870,7 +1871,7 @@ Else;
     EndIf;
 EndIf;
 ### End Epilog ###
-576,CubeAction=1511DataAction=1503CubeLogChanges=0
+576,_ParameterConstraints=e30=
 930,0
 638,1
 804,0


### PR DESCRIPTION
Update to enable Suppress zero cells. This can be very usefull when copying non-fed values.