### PR TITLE
Fix for }bedrock.cube.data.import - double character delimiters causes error when pMappingToNewDims used #203

### DIFF
--- a/main/}bedrock.cube.data.export.pro
+++ b/main/}bedrock.cube.data.export.pro
@@ -4,7 +4,7 @@
 586,"}APQ Staging TempSource"
 585,"}APQ Staging TempSource"
 564,
-565,"qO5Xa]f2aD@Co0fuAafaFlDL3<1>PbdBASiCL4KVD<nW]=qF:5UcvqGm61ADp6H=IgRJ<Ae40\bKtypsYQSC\ZgJjq`yZ6@OR0eq9i4IIEln>H6\1pS5MlDAfrQSpmrjJE7?G4JM\zRPpGNwz_t9u1RPj6\dPULBYXXOG01?Ury;`MS>XFj]LU@n4HOrTrWQ79\ThQkh"
+565,"bxa9KWb>7F1^]wakSdC1ek?DfBfYYv?eiI^@UK`A3wsu^jSSsa0ik]^h@V2zThr;KT8u3>beL7XV03EAtz:wu`fP:Uc[l2[2=?ReAC>c3fVYViTdP4;f9m\y`wW;hy[?Fsmg>WMWyGC@okhlv<?RbR6;TBE;fVoIY3qpCA\0209fhka?MzCmg:D39Ch\0WjaClFw?[LV"
 559,1
 928,0
 593,

--- a/main/}bedrock.cube.data.import.pro
+++ b/main/}bedrock.cube.data.import.pro
@@ -4,7 +4,7 @@
 586,"C:\TM1\Bedrock\Data\Bedrock.Z.Cube.Placeholder.csv"
 585,"C:\TM1\Bedrock\Data\Bedrock.Z.Cube.Placeholder.csv"
 564,
-565,"wq]Uk?tpJnK0zI=sNP?QaRsacW_V\YKnz2dj=<Ak6afZkl8h5l>uxzeIkBBwsGD1RmjHbWbxs5i3?AU]uYZmx4G5S4NXEetvYasC[M6x4ZpCiXo<OrFldPlY=Ue42b[RHVmCh]I[_?DqJru2fDvy14z5U4c<6[^8pquoC66u^aoegmkuV<J22LbnGaZZ9@VNf_=QPj]5"
+565,"hA`mpdQqaR:pmEbAo^piAEWOVw@7N2Du3BwwUDQcsY]<ksXEE1ahxxh1^CrPLQjhy2DST:sgX5;UJe9P9eOwVl9UuKpXkXyH\ACkwQrgxwq0UqUbmWznfruob:UBT0q2tmhTGa8b[GMl8=m=dQQZxzO^qib6mA?2?;t>EpHstUeym5gqUekvvycGnPWz7IhP\bND:Ets"
 559,1
 928,0
 593,
@@ -711,11 +711,11 @@ WHILE (nChar <= nCharCount);
         # Add the extra characters
         sDelim = sDelim | SUBST( sElementMapping, nChar + 1, nCount);
         # Move to the end of the delimter
-        nAddExtra = nCount;
+
       EndIf;
 
       If( sDelim @= sElementStartDelim );
-
+        nAddExtra = nCount;
         sChar = sDelim;
 
         If( sLastDelim @<> '' & sLastDelim @<> sDelimDim );

--- a/main/}bedrock.cube.data.import.pro
+++ b/main/}bedrock.cube.data.import.pro
@@ -4,7 +4,7 @@
 586,"C:\TM1\Bedrock\Data\Bedrock.Z.Cube.Placeholder.csv"
 585,"C:\TM1\Bedrock\Data\Bedrock.Z.Cube.Placeholder.csv"
 564,
-565,"bZaH\<FhYEJ[q_6T71fy2]Gi3IOtjqPj56EpSVa:GZs2DzC\0oMYQ>SE2rhi=?r;CDuyxhH9ZEYzWY7AbSx\7a4qNMJJdRl<m@xD2[?yC_B@8O6EKt<u8w<;aNbfJ>Df`NDSCb3Zw?EJ3U]7[394d0`\g4Yi=??<f:Aja<cPDPKFgk@6HaTFl7>hX6zS<Zq;e0S[j@UX"
+565,"wq]Uk?tpJnK0zI=sNP?QaRsacW_V\YKnz2dj=<Ak6afZkl8h5l>uxzeIkBBwsGD1RmjHbWbxs5i3?AU]uYZmx4G5S4NXEetvYasC[M6x4ZpCiXo<OrFldPlY=Ue42b[RHVmCh]I[_?DqJru2fDvy14z5U4c<6[^8pquoC66u^aoegmkuV<J22LbnGaZZ9@VNf_=QPj]5"
 559,1
 928,0
 593,
@@ -296,7 +296,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,927
+572,928
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -801,12 +801,13 @@ WHILE (nChar <= nCharCount);
           # Add the extra characters
           sDelim = sDelim | SUBST( sElementMapping, nChar + 1, nCount);
           # Move to the end of the delimter
-          nAddExtra = nCount;
+          
         EndIf;
 
         If( sDelim @= sDelimDim );
           nIsDelimiter = 1;
           sChar = sDelim;
+          nAddExtra = nCount;
         EndIf;
 
         If ( nIsDelimiter = 1 );


### PR DESCRIPTION
nAddExtra = nCount moved to olny trigger if match is found, otherwise for double character delimiters only every second character was checked.