### PR TITLE
Skip Cube name from export file

### DIFF
--- a/b3shell/Bedrock.Cube.Data.Export.pro
+++ b/b3shell/Bedrock.Cube.Data.Export.pro
@@ -4,7 +4,7 @@
 586,"}APQ Staging TempSource"
 585,"}APQ Staging TempSource"
 564,
-565,"lX@e=J@8S>\Na;U5QIdx:mytyJ8N75<l?V6=;Zk<rcVJ27ZVhMw`gLe>dG?eTl4[Dz@\lO0?cOt9Q8CQ]tjx@P321i@ueU[gRqwIu80V9ffH2evlcQ9S;cfHfVgZIXFVSJxY;n>p3Yg\9;Wx\[zVrC2Zu77iGeAam13zw[Ts6k?pGwZedAHl_^g9vFip8k\Rapg_8@^T"
+565,"z42K\2ba\uj8XfgZ_[3R2a98@GaJ]Ec?i@\=NwVKlpe41C[gSs03>q\cs6h^8M=qxV4lpaPVHcZe?^ig=>H1W4wGpyO>=hc=9xdad1363sg>n?K<sY:SP0_YK;Bd=>7IF>eDB]UHozg@ylOE=Ph[q:lFu=wDFB_?JlodE@^:9mUgTAlH`ftp=67?[<:js\DQmj9>TCkq"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,15
+560,18
 pCube
 pView
 pFilter
@@ -41,7 +41,10 @@ pFileName
 pDelimiter
 pQuote
 pDebug
-561,15
+pCubeNameExport
+pTitleRecord
+pSuppressZero
+561,18
 2
 2
 2
@@ -57,7 +60,10 @@ pDebug
 2
 2
 1
-590,15
+1
+1
+1
+590,18
 pCube,""
 pView,""
 pFilter,""
@@ -73,7 +79,10 @@ pFileName,""
 pDelimiter,","
 pQuote,""""
 pDebug,0
-637,15
+pCubeNameExport,1
+pTitleRecord,1
+pSuppressZero,1
+637,18
 pCube,"Cube"
 pView,"Temporary view name"
 pFilter,"Filter: Year: 2006 + 2007 & Scenario: Actual + Budget & Organization: North America Operations"
@@ -89,6 +98,9 @@ pFileName,"Export Filename (If Left Blank Defaults to cube_dim_ele_export.csv)"
 pDelimiter,"AsciiOutput delimiter character"
 pQuote,"AsciiOutput quote character"
 pDebug,"Debug Mode"
+pCubeNameExport,"Skip cube name from export file, including header (Skip = 0) (Default = 1)"
+pTitleRecord,"Include Title Record in Export File? (Boolean 0=false, 1=true, 2=title and filter line Default=1)"
+pSuppressZero,"Suppress Zero Values (1=Suppress)"
 577,0
 578,0
 579,0
@@ -96,7 +108,7 @@ pDebug,"Debug Mode"
 581,0
 582,0
 603,0
-572,91
+572,95
 
 #****Begin: Generated Statements***
 #****End: Generated Statements****
@@ -144,6 +156,9 @@ If( pDebug >= 1 );
   AsciiOutput( sDebugFile, '            pFileName:          ' | pFileName );
   AsciiOutput( sDebugFile, '            pDelimiter:         ' | pDelimiter );
   AsciiOutput( sDebugFile, '            pQuote:             ' | pQuote );
+  AsciiOutput( sDebugFile, '            pCubeNameExport:	 ' | NumberToString( pCubeNameExport ) );
+  AsciiOutput( sDebugFile, '            pTitleRecord:		 ' | NumberToString( pTitleRecord ) );
+  AsciiOutput( sDebugFile, '            pSuppressZero:		 ' | NumberToString( pSuppressZero ) );
   AsciiOutput( sDebugFile, '' );
   AsciiOutput( sDebugFile, '' );
 EndIf;
@@ -162,7 +177,7 @@ nRet = ExecuteProcess( sProc,
   'pDimDelim', pDimensionDelim,
   'pEleStartDelim', pElementStartDelim,
   'pEleDelim', pElementDelim,
-  'pSuppressZero', 1,
+  'pSuppressZero', pSuppressZero,
   'pSuppressConsol', pSkipCons,
   'pSuppressRules', pSkipRules,
   'pZeroSource', pZeroSource,
@@ -172,7 +187,8 @@ nRet = ExecuteProcess( sProc,
   'pFileName', pFileName,
   'pDelim', pDelimiter,
   'pQuote', pQuote,
-  'pTitleRecord', 1
+  'pTitleRecord', pTitleRecord, 
+  'pCubeNameExport', pCubeNameExport
 );
 
 IF ( nRet <> ProcessExitNormal() );

--- a/main/}bedrock.cube.data.export.pro
+++ b/main/}bedrock.cube.data.export.pro
@@ -4,7 +4,7 @@
 586,"}APQ Staging TempSource"
 585,"}APQ Staging TempSource"
 564,
-565,"bxa9KWb>7F1^]wakSdC1ek?DfBfYYv?eiI^@UK`A3wsu^jSSsa0ik]^h@V2zThr;KT8u3>beL7XV03EAtz:wu`fP:Uc[l2[2=?ReAC>c3fVYViTdP4;f9m\y`wW;hy[?Fsmg>WMWyGC@okhlv<?RbR6;TBE;fVoIY3qpCA\0209fhka?MzCmg:D39Ch\0WjaClFw?[LV"
+565,"uy30;`w7eCnQ<uj=l=Ek8aM>[^JWN]QLPe5W\Ga8h]kxm56_z<_0z8Hnqu^Q;U_vac\S:ZB9Em0AI9yqg;=I;e1kyyN]zZFJ3<4F0pFkMw1Cm]bJxqT>K9TZF_i4aur7cSinv\LB37x9O^]rv\cA5K@Top6L:NbTGpv4C`x]KtQam@L;iPL92Qv6Vr1F<6gF:mx7WNf_"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,25
+560,26
 pLogoutput
 pStrictErrorHandling
 pCube
@@ -51,7 +51,8 @@ pTitleRecord
 pSandbox
 pSubN
 pCharacterSet
-561,25
+pCubeNameExport
+561,26
 1
 1
 2
@@ -77,7 +78,8 @@ pCharacterSet
 2
 1
 2
-590,25
+1
+590,26
 pLogoutput,0
 pStrictErrorHandling,0
 pCube,""
@@ -103,7 +105,8 @@ pTitleRecord,1
 pSandbox,""
 pSubN,0
 pCharacterSet,"TM1CS_UTF8"
-637,25
+pCubeNameExport,1
+637,26
 pLogoutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
 pStrictErrorHandling,"OPTIONAL: On encountering any error, exit with major error status by ProcessQuit after writing to the server message log (Boolean True = 1)"
 pCube,"REQUIRED: Cube name"
@@ -129,7 +132,8 @@ pTitleRecord,"OPTIONAL: Include Title Record in Export File? (Boolean 0=false, 1
 pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid name will result in process error)"
 pSubN,"OPTIONAL: Create N level subset for all dims not mentioned in pFilter"
 pCharacterSet,"OPTIONAL: The output character set (defaults to TM1CS_UTF8 if blank)"
-577,101
+pCubeNameExport,"OPTIONAL: Skip cube name from export file, including header (Skip = 0) (Default = 1)"
+577,104
 V1
 V2
 V3
@@ -231,7 +235,10 @@ V98
 V99
 V100
 Value
-578,101
+NVALUE
+SVALUE
+VALUE_IS_STRING
+578,104
 2
 2
 2
@@ -333,7 +340,10 @@ Value
 2
 2
 2
-579,101
+1
+2
+1
+579,104
 1
 2
 3
@@ -435,10 +445,10 @@ Value
 99
 100
 101
-580,101
 0
 0
 0
+580,104
 0
 0
 0
@@ -537,7 +547,16 @@ Value
 0
 0
 0
-581,101
+0
+0
+0
+0
+0
+0
+581,104
+0
+0
+0
 0
 0
 0
@@ -742,7 +761,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,395
+572,420
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1061,23 +1080,48 @@ Else;
   # Determine number of dims in source cube & create strings to expand on title and rows 
   nCount = 1;
   nDimensionIndex = 0;
-  sTitle = '%pQuote%Cube%pQuote%';
-  sRow = '%pQuote%%pCube%%pQuote%';
-  While( TabDim( pCube, nCount ) @<> '' );
-      sDimension = TabDim( pCube, nCount );
-      
-      ## Determine title string for the source cube
-      sTitle = sTitle|'%pFieldDelim%%pQuote%'|sDimension|'%pQuote%';
-      # Determine row string for the source cube
-      sRow = sRow|'%pFieldDelim%%pQuote%%V'| numbertostring(nCount) |'%%pQuote%';
-      
-      nCount = nCount + 1;
-  End;
-  nDimensionCount = nCount - 1;
-  
-  # Finish off the strings
-  sTitle = sTitle|'%pFieldDelim%%pQuote%Value%pQuote%';
-  sRow = sRow|'%pFieldDelim%%pQuote%%sValue%%pQuote%';
+
+  ## Skip cube name from export
+  IF (pCubeNameExport = 0);
+    sTitle = '';
+    sRow = '';
+
+    While( TabDim( pCube, nCount ) @<> '' );
+        sDimension = TabDim( pCube, nCount );
+
+        ## Determine title string for the source cube
+        sTitle = sTitle|'%pQuote%'|sDimension|'%pQuote%%pFieldDelim%';
+        # Determine row string for the source cube
+        sRow = sRow|'%pQuote%%V'| numbertostring(nCount) |'%%pQuote%%pFieldDelim%';
+
+        nCount = nCount + 1;
+    End;
+    nDimensionCount = nCount - 1;
+
+    # Finish off the strings 
+    sTitle = sTitle|'%pQuote%Value%pQuote%';
+    sRow = sRow|'%pQuote%%sValue%%pQuote%';
+
+  ELSE;
+    sTitle = '%pQuote%Cube%pQuote%';
+    sRow = '%pQuote%%pCube%%pQuote%';
+
+    While( TabDim( pCube, nCount ) @<> '' );
+        sDimension = TabDim( pCube, nCount );
+
+        ## Determine title string for the source cube
+        sTitle = sTitle|'%pFieldDelim%%pQuote%'|sDimension|'%pQuote%';
+        # Determine row string for the source cube
+        sRow = sRow|'%pFieldDelim%%pQuote%%V'| numbertostring(nCount) |'%%pQuote%';
+
+        nCount = nCount + 1;
+    End;
+    nDimensionCount = nCount - 1;
+
+    # Finish off the strings
+    sTitle = sTitle|'%pFieldDelim%%pQuote%Value%pQuote%';
+    sRow = sRow|'%pFieldDelim%%pQuote%%sValue%%pQuote%';
+  ENDIF;
   
   # Create Processing View for source version 
   nRet = ExecuteProcess('}bedrock.cube.view.create',


### PR DESCRIPTION
Hello, 

We added a new option to skip the export of Cube name from export file in base process "}bedrock.cube.data.export".
A new paramter "pCubeNameExport" is added for that reason.
Additionally two extra parameters have been extended to "Bedrock.Cube.Data.Export" process (pTitleRecord and pSuppressZero).

The reason for this change is our internal TI processes are using format without cubename and additionally we use exported files to move data on database. 
Our ETL tools do not anticipate cubename in each row and would have to be changed. 
Not all exported flat files are used to import data back into TM1 instance and this feature is purely optional (the default value exports cubename). 

Kind regards, Matic