### PR TITLE
Wrong parameter type for pStrictErrorHandling in shell processes

### DIFF
--- a/b3shell/Bedrock.Dim.Element.Component.Add.pro
+++ b/b3shell/Bedrock.Dim.Element.Component.Add.pro
@@ -4,7 +4,7 @@
 586,
 585,
 564,
-565,"htv@9ngya[5u56e_tlDPY18olB`B7HiCrV?r;KGEvrdah`Ykb<zjf8EKHL4pn8Zu=BEm9>?=hprj3<qI1=b\e3kt:jG;cYX^@QccSYVi15\HZp9uURs:e[7CfUh1MfaD>KQIsC=^OV:CV>=j4]=A1T;SFKfQUuySQ0IxIC4f\tRjuJgx@;[:wmz^`hwi:z3CXaz>5sna"
+565,"danQaxIDLfC8qpRt\9<SPz>auP1nE:u4fEnOpKkkhvg^8I<;rUXSH@0T:U[::D[mrPLd^i@q[]Y1i@tWFZ6qlDmFUkaUU34^pEymUi0V0a\kkIT^rsIz_a\=7SlFb3w^ywBU<Q5^6eDiBsoBPF?Hz=\Qf]`c:iDR;[Aj\u5FYNKu4t=exZIqC5oGe]YjvX]gTDyUu6l["
 559,1
 928,0
 593,
@@ -96,7 +96,7 @@ EndIf;
 
 nRet = EXECUTEPROCESS('}bedrock.hier.element.move',
   'pLogOutput', pDebug,
-  'pStrictErrorHandling','1',
+  'pStrictErrorHandling',1,
   'pDim', pDimension,
   'pHier', '',
   'pEle', pElement,

--- a/b3shell/Bedrock.Dim.Element.Create.pro
+++ b/b3shell/Bedrock.Dim.Element.Create.pro
@@ -4,7 +4,7 @@
 586,
 585,
 564,
-565,"r95THfhjSgS0;6\07waA@Td>oAIqI^mRvbG7TVrJ9d0PJ\Jgal1kW[DQjctFfv7fKocbv_?U<BdnugO]Uo_oj7H9tCM1viP^fPFhfLArXs@35xnL4=4]^u0C?TgiZ1x;FK>Ej6pXd8^bQHf`z[8]rJi1PG3ZC6Mr_5RlQLlOAb`hkfU]XFADPV3gr1n[\PIQ>CX4n4n="
+565,"r`o07Mq]FvmC1M:m5aahO52o1cGJCOIgezpLQy;4[hxB>axvciE:hbIOu==Jxf1eHPg@^N_?>rL93Ys>M50JXqNx0zdH7@bUz^f7U4n8tlJtnDI>x[U2^e7YFEm=P2RxwefHF^0BLBtB<u7?MT`[<YT5k5jGow1LFj:FrF<viU`nIS\b<6RFocYYX8n`:@xqttL<GsL<"
 559,1
 928,0
 593,
@@ -98,7 +98,7 @@ EndIf;
 
 nRet = EXECUTEPROCESS('}bedrock.hier.element.create',
   'pLogOutput', pDebug,
-  'pStrictErrorHandling','1',
+  'pStrictErrorHandling',1,
   'pDim', pDimension,
   'pHier', '',
   'pEle', pElement,


### PR DESCRIPTION
Wrong parameter type for pStrictErrorHandling in shell processes Bedrock.Dim.Element.Component.Add and Bedrock.Dim.Element.Create #253