### PR TITLE
TI syntax highlighting in Notepad++ is improved

### DIFF
--- a/main/}bedrock.cube.data.copy.intercube.pro
+++ b/main/}bedrock.cube.data.copy.intercube.pro
@@ -124,7 +124,7 @@ pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of
 pSandbox,"OPTIONAL: To use sandbox not base data enter the sandbox name (invalid name will result in process error)"
 pFile,"OPTIONAL: Copy via file export and import. Reduces locks (0 = no, 1= use file and delete it 2= use file and retain it)"
 pSubN,"OPTIONAL: Create N level subset for all dims not mentioned in pFilter"
-pThreadMode,"DO NOT USE: Internal parameter only, please don't use"
+pThreadMode,"DO NOT USE: Internal parameter only, please do not use"
 577,29
 V1
 V2


### PR DESCRIPTION
The single quote in "don't" makes the syntax highlighting go wrong as of that character in the PRO file. With a very small change it is correct again.