### PR TITLE
Empty pDim as the mapping and smaller changes

### DIFF
--- a/main/}bedrock.security.cube.cellsecurity.create.pro
+++ b/main/}bedrock.security.cube.cellsecurity.create.pro
@@ -101,7 +101,7 @@ cLogInfo            = 'Process:%cThisProcName% run with parameters pCube:%pCube%
 cDelim              = ':';
 
 ## LogOutput parameters
-IF( pLogoutput = 1 );
+IF( pLogOutput = 1 );
     LogOutput('INFO', Expand( cLogInfo ) );   
 ENDIF;
 
@@ -136,13 +136,13 @@ If( nErrors <> 0 );
 EndIf;
 
 ### Count dimensions in cube ###
-nDims               = 0;
-iDim                = 1;
-While( TabDim( pCube, iDim ) @<> '' );
-   nDims            = iDim;
-   iDim             = iDim + 1;
-End;
+nDims               = CubeDimensionCountGet( pCube );
 
+### If pDim is empty, then no restrictions on dimensions ###
+pDim = Trim( pDim );
+If( pDim @= '' );
+   pDim = Fill( '1:', 2 * nDims - 1 );
+EndIf;
 ### Count dimensions mapped in pDim ###
 sDimensions         = pDim;
 nDelimiterIndex     = 1;


### PR DESCRIPTION
I would find it an improvement to use pDim = '' and then have all dimensions included in the cell security cube.
Other than that, smaller changes to the process and getting rid of the Tabdim function in favor of CubeDimensionCountGet.