### PR TITLE
For consistency: ExecuteProcess instead of EXECUTEPROCESS

### DIFF
--- a/main/}bedrock.cube.dimension.add.pro
+++ b/main/}bedrock.cube.dimension.add.pro
@@ -271,7 +271,7 @@ EndIf;
 IF(pIncludeRules = 1 % pIncludeRules = 2);
   
   sProc = '}bedrock.cube.rule.manage';
-  nRet = EXECUTEPROCESS( sProc,
+  nRet = ExecuteProcess( sProc,
     'pLogOutput', pLogOutput,
     'pStrictErrorHandling', pStrictErrorHandling,
     'pCube', pCube,
@@ -299,7 +299,7 @@ IF(pIncludeData = 1);
     nSuppressRules = IF(nIncludeRules = 1,  1, 0);
   
     sProc = '}bedrock.cube.clone';
-    nRet = EXECUTEPROCESS( sProc,
+    nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pSrcCube', pCube,
@@ -357,8 +357,8 @@ IF(pIncludeData = 1);
   	'pFilter','',
   	'pTgtCube',pCube,
   	'pMappingToNewDims',sMappingToNewDims,
-    'pSuppressConsol', 1,
-    'pSuppressRules', nSuppressRules,
+        'pSuppressConsol', 1,
+        'pSuppressRules', nSuppressRules,
   	'pZeroTarget',0,
   	'pZeroSource',0,
   	'pFactor',1,
@@ -382,7 +382,7 @@ IF(pIncludeData = 1);
     # destroy clone cube
     IF(pTemp=1);
         sProc = '}bedrock.cube.delete';
-        nRet = EXECUTEPROCESS( sProc,
+        nRet = ExecuteProcess( sProc,
             'pLogOutput', pLogOutput,
             'pStrictErrorHandling', pStrictErrorHandling,
             'pCube', pCloneCube,
@@ -408,7 +408,7 @@ IF(pIncludeRules = 2);
   
     sProc = '}bedrock.cube.rule.manage';
 
-    nRet = EXECUTEPROCESS( sProc,
+    nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pCube', pCube,
@@ -427,7 +427,7 @@ IF(pIncludeRules = 2);
         LogOutput(cMsgErrorLevel, 'Rule could not be attached due to invalid !Dimension references. Please recover from the backup and fix manually.');
       ENDIF;
       
-      EXECUTEPROCESS( sProc,
+      ExecuteProcess( sProc,
       'pLogOutput', pLogOutput,
       'pStrictErrorHandling', pStrictErrorHandling,
       'pCube', pCube,

--- a/main/}bedrock.cube.dimension.delete.pro
+++ b/main/}bedrock.cube.dimension.delete.pro
@@ -229,7 +229,7 @@ IF(pIncludeRules = 1 % pIncludeRules = 2);
   
   sProc = '}bedrock.cube.rule.manage';
 
-  nRet = EXECUTEPROCESS( sProc,
+  nRet = ExecuteProcess( sProc,
     'pLogOutput', pLogOutput,
     'pStrictErrorHandling', pStrictErrorHandling,
     'pCube', pCube,
@@ -256,7 +256,7 @@ IF(pIncludeData = 1);
     nSuppressRules = IF(nIncludeRules = 1,  1, 0);
   
     sProc = '}bedrock.cube.clone';
-    nRet = EXECUTEPROCESS( sProc,
+    nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pSrcCube', pCube,
@@ -340,7 +340,7 @@ IF(pIncludeData = 1);
     # destroy clone cube
     IF(pTemp=1);
         sProc = '}bedrock.cube.delete';
-        nRet = EXECUTEPROCESS( sProc,
+        nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pCube', pCloneCube,
@@ -366,7 +366,7 @@ IF(pIncludeRules = 2);
   
   sProc = '}bedrock.cube.rule.manage';
 
-  nRet = EXECUTEPROCESS( sProc,
+  nRet = ExecuteProcess( sProc,
     'pLogOutput', pLogOutput,
     'pStrictErrorHandling', pStrictErrorHandling,
     'pCube', pCube,
@@ -385,7 +385,7 @@ IF(pIncludeRules = 2);
       LogOutput(cMsgErrorLevel, 'Rule could not be attached due to invalid !Dimension references. Please recover from the backup and fix manually.');
     ENDIF;
 
-    EXECUTEPROCESS( sProc,
+    ExecuteProcess( sProc,
     'pLogOutput', pLogOutput,
     'pStrictErrorHandling', pStrictErrorHandling,
     'pCube', pCube,

--- a/main/}bedrock.cube.dimension.replace.pro
+++ b/main/}bedrock.cube.dimension.replace.pro
@@ -281,7 +281,7 @@ EndIf;
 IF(pIncludeRules = 1 % pIncludeRules = 2);
     sProc = '}bedrock.cube.rule.manage';
 
-    nRet = EXECUTEPROCESS( sProc,
+    nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pCube', pCube,
@@ -309,7 +309,7 @@ IF(pIncludeData = 1);
      nSuppressRules = IF(nIncludeRules = 1,  1, 0);
   
     sProc = '}bedrock.cube.clone';
-    nRet = EXECUTEPROCESS( sProc,
+    nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pSrcCube', pCube,
@@ -369,8 +369,8 @@ IF(pIncludeData = 1);
 	    'pFilter','',
 	    'pTgtCube',pCube,
 	    'pMappingToNewDims',sMappingToNewDims,
-        'pSuppressConsol', 1,
-        'pSuppressRules', nSuppressRules,
+            'pSuppressConsol', 1,
+            'pSuppressRules', nSuppressRules,
 	    'pZeroTarget',0,
 	    'pZeroSource',0,
 	    'pFactor',1,
@@ -394,7 +394,7 @@ IF(pIncludeData = 1);
     # destroy clone cube
     IF(pTemp=1);
         sProc = '}bedrock.cube.delete';
-        nRet = EXECUTEPROCESS( sProc,
+        nRet = ExecuteProcess( sProc,
             'pLogOutput', pLogOutput,
             'pStrictErrorHandling', pStrictErrorHandling,
             'pCube', pCloneCube,
@@ -420,7 +420,7 @@ IF(pIncludeRules = 2);
   
     sProc = '}bedrock.cube.rule.manage';
 
-    nRet = EXECUTEPROCESS( sProc,
+    nRet = ExecuteProcess( sProc,
         'pLogOutput', pLogOutput,
         'pStrictErrorHandling', pStrictErrorHandling,
         'pCube', pCube,
@@ -439,7 +439,7 @@ IF(pIncludeRules = 2);
         LogOutput(cMsgErrorLevel, 'Rule could not be attached due to invalid !Dimension references. Please recover from the backup and fix manually.');
       ENDIF;
 
-      EXECUTEPROCESS( sProc,
+      ExecuteProcess( sProc,
       'pLogOutput', pLogOutput,
       'pStrictErrorHandling', pStrictErrorHandling,
       'pCube', pCube,

--- a/main/}bedrock.dim.clone.pro
+++ b/main/}bedrock.dim.clone.pro
@@ -437,7 +437,7 @@ If( pHier @= '*' );
         If(nElestart > 1);
           vSourceHierarchy = SUBST(sEle,nElestart,nElength);
          If ( vSourceHierarchy @<> 'Leaves');
-             nRet = EXECUTEPROCESS('}bedrock.hier.clone',
+             nRet = ExecuteProcess('}bedrock.hier.clone',
                'pLogOutput', pLogOutput,
                'pStrictErrorHandling', pStrictErrorHandling,
                'pSrcDim', sDim,
@@ -470,7 +470,7 @@ ElseIf( Scan( '*', pHier )=0 &  Scan( '?', pHier )=0 & Scan( pDelim, pHier )=0 &
         sMessage = Expand( 'Hierarchy "%sCurrHierName%" in Dimension "%sDim%" being processed....' );
         LogOutput( 'INFO', Expand( cMsgInfoContent ) );
       EndIf;
-      nRet = EXECUTEPROCESS('}bedrock.hier.clone',
+      nRet = ExecuteProcess('}bedrock.hier.clone',
        'pLogOutput', pLogOutput,
        'pStrictErrorHandling', pStrictErrorHandling,
        'pSrcDim', sDim,
@@ -513,7 +513,7 @@ ElseIf( Scan( '*', pHier )=0 &  Scan( '?', pHier )=0 & Trim( pHier ) @<> '' );
             sMessage = Expand( 'Hierarchy "%sCurrHierName%" in Dimension "%sDim%" being processed....' );
             LogOutput( 'INFO', Expand( cMsgInfoContent ) );
           EndIf;
-          nRet = EXECUTEPROCESS('}bedrock.hier.clone',
+          nRet = ExecuteProcess('}bedrock.hier.clone',
            'pLogOutput', pLogOutput,
            'pStrictErrorHandling', pStrictErrorHandling,
            'pSrcDim', sDim,
@@ -580,7 +580,7 @@ ElseIf( Trim( pHier ) @<> '' );
             sMessage = Expand( 'Hierarchy "%sCurrHierName%" in Dimension "%sDim%" being processed....' );
             LogOutput( 'INFO', Expand( cMsgInfoContent ) );
           EndIf;
-          nRet = EXECUTEPROCESS('}bedrock.hier.clone',
+          nRet = ExecuteProcess('}bedrock.hier.clone',
            'pLogOutput', pLogOutput,
            'pStrictErrorHandling', pStrictErrorHandling,
            'pSrcDim', sDim,

--- a/main/}bedrock.hier.clone.pro
+++ b/main/}bedrock.hier.clone.pro
@@ -453,7 +453,7 @@ EndIf;
   
 ### If a new dimension has been created, call the process recursively to clone the alternate hierarchy, after the same named hierarchy has been processed
 If( nProcessSameNamedHier = 1 );
-  nRet = EXECUTEPROCESS('}bedrock.hier.clone',
+  nRet = ExecuteProcess('}bedrock.hier.clone',
     'pLogOutput', pLogOutput,
     'pStrictErrorHandling', pStrictErrorHandling,
     'pSrcDim', pSrcDim,


### PR DESCRIPTION
Not very important but at least there is now everywhere ExecuteProcess instead of ExecuteProcess mixed with EXECUTEPROCESS in uppercase. 20 such upper case cases changed in 5 files. RunProcess was consistent everywhere.