### PR TITLE
Update }bedrock.server.encrypt.file.pro

### DIFF
--- a/main/}bedrock.server.encrypt.file.pro
+++ b/main/}bedrock.server.encrypt.file.pro
@@ -72,7 +72,7 @@ pAction,"REQUIRED: 5 = unencrypt, 4 = encrypt"
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
-    ExecuteProcess('}bedrock.server.encrypt.directory', 'pLogOutput', pLogOutput,
+    ExecuteProcess('}bedrock.server.encrypt.file', 'pLogOutput', pLogOutput,
        'pStrictErrorHandling', pStrictErrorHandling,
        'pSourcePath', pSourcePath,
        'pSourceFile', pSourceFile,


### PR DESCRIPTION
Just a small typo.

I caught it when setting up a tree of process executions. I use regex to search for instances of "ExecuteProcess" so I find it in the Prolog tab. But with this particular typo, "}bedrock.server.encrypt.file" would execute "}bedrock.server.encrypt.directory" which in turn executes "}bedrock.server.encrypt.file", ad aeternam. Circular references in my tree causing havoc.