### PR TITLE
Adding pIncludeDescendants parameter

### DIFF
--- a/main/}bedrock.cube.data.copy.pro
+++ b/main/}bedrock.cube.data.copy.pro
@@ -4,7 +4,7 @@
 586,"zzSYS 50 Dim Cube"
 585,"zzSYS 50 Dim Cube"
 564,
-565,"ufv\E]Lwc4ImdBqI=a@JCyACmL;09U8=qn9p7DugHBov9fi7HUYPJn^b45Fa;MI[AaF2AGR92gjqkqC_[mZ4dtdeKr{J1V55;2H6}A=WGsRWzYwWHkV][YHE=v91D=En2L;X7A[d;4svFq=^D?n8}\2Yf4d<enAt@D4hqdhXGNR7FjM]<Vn_\G]z<hJ=hPe2KW=vMF6"
+565,"ss[X>tC6YR?4vgEg9HKyuDGD?d`LE:`4QBHm=7zhXDdori9C[BwS=>1f7=FQ?qEK4ia<azGHmtiqipcz<;d4Y0\FdNqj_LizPyp>]IKMD:?7A]}WxsWS90<fj=]CK}<gwNk_gvsE@fJpF4k\tvK8Mm7^>W2Qf01sdp>XrHgx\0?3EZ3Q9LImI@=P0s=jKz0dRfIUe[VK"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,33
+560,34
 pLogOutput
 pStrictErrorHandling
 pCube
@@ -44,6 +44,7 @@ pSuppressConsol
 pSuppressConsolStrings
 pSuppressRules
 pSuppressZero
+pIncludeDescendants
 pCumulate
 pZeroTarget
 pZeroSource
@@ -59,7 +60,7 @@ pSubN
 pThreadMode
 pThreadControlFile
 pMaxWaitSeconds
-561,33
+561,34
 1
 1
 2
@@ -83,17 +84,18 @@ pMaxWaitSeconds
 1
 1
 1
-2
-1
-2
-2
-2
-2
-1
 1
 2
 1
-590,33
+2
+2
+2
+2
+1
+1
+2
+1
+590,34
 pLogOutput,0
 pStrictErrorHandling,0
 pCube,""
@@ -112,6 +114,7 @@ pSuppressConsol,1
 pSuppressConsolStrings,0
 pSuppressRules,1
 pSuppressZero,1
+pIncludeDescendants,0
 pCumulate,0
 pZeroTarget,1
 pZeroSource,0
@@ -127,7 +130,7 @@ pSubN,0
 pThreadMode,0
 pThreadControlFile,""
 pMaxWaitSeconds,1800
-637,33
+637,34
 pLogOutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
 pStrictErrorHandling,"OPTIONAL: On encountering any error, exit with major error status by ProcessQuit after writing to the server message log (Boolean True = 1)"
 pCube,"REQUIRED: Cube"
@@ -146,6 +149,7 @@ pSuppressConsol,"OPTIONAL: Suppress Consolidated Cells (Skip = 1)"
 pSuppressConsolStrings,"OPTIONAL: Suppress Consolidated String Cells (Skip = 1)"
 pSuppressRules,"OPTIONAL: Suppress Rules (Skip = 1)"
 pSuppressZero,"OPTIONAL: Suppress Null Cells (Skip = 1)"
+pIncludeDescendants,"OPTIONAL: Include all descendants when copying consolidated values"
 pCumulate,"OPTIONAL: 1 = Add source to existing value in target (if zero out target = 0 False). 0 = Replace target with source."
 pZeroTarget,"OPTIONAL: Zero out Target Element PRIOR to Copy? (Boolean 1=True)"
 pZeroSource,"OPTIONAL: Zero out Source Element AFTER Copy? (Boolean 1=True)"
@@ -474,7 +478,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=33ColType=827
 603,0
-572,1030
+572,1032
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -484,7 +488,7 @@ If( 1 = 0 );
     	'pFilterParallel', '', 'pParallelThreads', 0,
     	'pEleMapping', '', 'pMappingDelim', '->',
     	'pDimDelim', '&', 'pEleStartDelim', '¦', 'pEleDelim', '+',
-    	'pFactor', 1, 'pSuppressConsol', 1, 'pSuppressConsolStrings', 0, 'pSuppressRules', 1, 'pSuppressZero', 1, 'pCumulate', 0,
+    	'pFactor', 1, 'pSuppressConsol', 1, 'pSuppressConsolStrings', 0, 'pSuppressRules', 1, 'pSuppressZero', 1, 'pIncludeDescendants',0, 'pCumulate', 0,
     	'pZeroTarget', 1, 'pZeroSource', 0,
     	'pTemp', 1, 'pCubeLogging', 0, 'pSandbox', '', 
     	'pFile', 0, 'pDelim', ',', 'pQuote', '"', 'pDecimalSeparator', '.', 'pThousandSeparator', ',', 'pSubN', 0
@@ -541,7 +545,7 @@ cRandomInt      = NumberToString( INT( RAND( ) * 1000 ));
 cTempSub        = cThisProcName |'_'| cTimeStamp |'_'| cRandomInt;
 cMsgErrorLevel  = 'ERROR';
 cMsgErrorContent= 'Process:%cThisProcName% ErrorMsg:%sMessage%';
-cLogInfo        = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pSrcView:%pSrcView%, pTgtView:%pTgtView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pEleMapping:%pEleMapping%, pMappingDelim:%pMappingDelim%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pFactor:%pFactor%, pSuppressConsol:%pSuppressConsol%, pSuppressConsolStrings:%pSuppressConsolStrings%, pSuppressRules:%pSuppressRules%, pSuppressZero:%pSuppressZero%, pCumulate:%pCumulate%, pZeroTarget:%pZeroTarget%, pZeroSource:%pZeroSource%, pTemp:%pTemp%, pCubeLogging:%pCubeLogging%, pSandbox:%pSandbox%, pFile:%pFile%.';
+cLogInfo        = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pSrcView:%pSrcView%, pTgtView:%pTgtView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pEleMapping:%pEleMapping%, pMappingDelim:%pMappingDelim%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pFactor:%pFactor%, pSuppressConsol:%pSuppressConsol%, pSuppressConsolStrings:%pSuppressConsolStrings%, pSuppressRules:%pSuppressRules%, pSuppressZero:%pSuppressZero% pIncludeDescendants %pIncludeDescendants% pCumulate:%pCumulate%  pZeroTarget:%pZeroTarget%, pZeroSource:%pZeroSource%, pTemp:%pTemp%, pCubeLogging:%pCubeLogging%, pSandbox:%pSandbox%, pFile:%pFile%.';
 cDefaultView    = Expand( '%cThisProcName%_%cTimeStamp%_%cRandomInt%' );
 
 ## LogOutput parameters
@@ -1414,6 +1418,7 @@ Else;
       'pSuppressConsol', nSuppressConsol,
       'pSuppressRules', pSuppressRules,
       'pSuppressConsolStrings', pSuppressConsolStrings,
+      'pIncludeDescendants',pIncludeDescendants,
       'pDimDelim', pDimDelim,
       'pEleStartDelim', pEleStartDelim,
       'pEleDelim', pEleDelim ,
@@ -1457,6 +1462,7 @@ Else;
        'pSuppressConsol', nSuppressConsol,
        'pSuppressRules', pSuppressRules,
        'pSuppressConsolStrings', pSuppressConsolStrings,
+       'pIncludeDescendants',pIncludeDescendants,
        'pZeroSource', 0,
        'pCubeLogging', pCubeLogging,
        'pTemp', pTemp,

--- a/main/}bedrock.cube.data.export.pro
+++ b/main/}bedrock.cube.data.export.pro
@@ -4,7 +4,7 @@
 586,"}APQ Staging TempSource"
 585,"}APQ Staging TempSource"
 564,
-565,"dR9EasiRdMAe1MsPckbqP]CP9sSA_sm1QdBvDlwbfM5f@d2\XeGaf2Nd=C>eL?^5<hkwzGFQVS8A4gVM>]<Ov3nAjZc0]y0iB@IiFb5X@`k;y9wOc]\U3C0cnQ>LdNbAWFuGqLB4^lk6T_Y@hhqseCe^CeOyk67J:rH6EH>w5o^GJ_FrGwkTdKX44H?4QGgngo_1qhnD"
+565,"k6LX;[ANEe8aDicM8WIF0F@ZtUyRN48\uJO7X@zymRj3eF`F@LmRQ6RFQUYnXs5M=N5?7EaRm:F]aBzcapy]Vef7g@K9yqW8[Gn3ycAKjzXRr:6yeudy]FrR?11?xC7uBh9O_gLz@xz1:t<eBbFhKu>=Hs_AO=krHKq6@O]j_0Sc9<RT\O6uJQcy[K:SFNBt4aY?[3Iv"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,28
+560,29
 pLogoutput
 pStrictErrorHandling
 pCube
@@ -40,6 +40,7 @@ pSuppressZero
 pSuppressConsol
 pSuppressRules
 pSuppressConsolStrings
+pIncludeDescendants
 pZeroSource
 pCubeLogging
 pTemp
@@ -54,7 +55,7 @@ pSandbox
 pSubN
 pCharacterSet
 pCubeNameExport
-561,28
+561,29
 1
 1
 2
@@ -72,6 +73,7 @@ pCubeNameExport
 1
 1
 1
+1
 2
 2
 2
@@ -83,7 +85,7 @@ pCubeNameExport
 1
 2
 1
-590,28
+590,29
 pLogoutput,0
 pStrictErrorHandling,0
 pCube,""
@@ -98,6 +100,7 @@ pSuppressZero,1
 pSuppressConsol,1
 pSuppressRules,1
 pSuppressConsolStrings,0
+pIncludeDescendants,0
 pZeroSource,0
 pCubeLogging,0
 pTemp,1
@@ -112,7 +115,7 @@ pSandbox,""
 pSubN,0
 pCharacterSet,""
 pCubeNameExport,1
-637,28
+637,29
 pLogoutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
 pStrictErrorHandling,"OPTIONAL: On encountering any error, exit with major error status by ProcessQuit after writing to the server message log (Boolean True = 1)"
 pCube,"REQUIRED: Cube name"
@@ -127,6 +130,7 @@ pSuppressZero,"OPTIONAL: Suppress Zero Values (1=Suppress)"
 pSuppressConsol,"OPTIONAL: Suppress Consolidated Values? (1=Suppress)"
 pSuppressRules,"OPTIONAL: Suppress Rule Values? (1=Suppress)"
 pSuppressConsolStrings,"OPTIONAL: Suppress Strings on Consolidations (Skip = 1) (Default = 0)"
+pIncludeDescendants,""
 pZeroSource,"OPTIONAL: Zero Out view AFTER Copy? (Boolean 1=True)"
 pCubeLogging,"Required: Cube Logging (0 = No transaction logging, 1 = Logging of transactions, 2 = Ignore Cube Logging - No Action Taken)"
 pTemp,"OPTIONAL: Retain temporary view and Subset ( 0 = retain View and Subsets 1 = use temp objects)"
@@ -754,7 +758,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,487
+572,488
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -763,7 +767,7 @@ If( 1 = 0 );
     	'pCube', '', 'pView', '', 'pFilter', '',
     	'pFilterParallel', '', 'pParallelThreads', 0,
     	'pDimDelim', '&', 'pEleStartDelim', '¦', 'pEleDelim', '+',
-    	'pSuppressZero', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressConsolStrings', 1,
+    	'pSuppressZero', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressConsolStrings', 1, 'pIncludeDescendants',0,
     	'pZeroSource', 0, 'pCubeLogging', 0, 'pTemp', 1,
     	'pFilePath', '', 'pFileName', '',
     	'pDelim', ',','pDecimalSeparator','.','pThousandSeparator',',',
@@ -818,7 +822,7 @@ cTimeStamp        = TimSt( Now, '\Y\m\d\h\i\s' );
 cRandomInt        = NumberToString( INT( RAND( ) * 1000 ));
 cMsgErrorLevel    = 'ERROR';
 cMsgErrorContent  = 'User:%cUserName% Process:%cThisProcName% ErrorMsg:%sMessage%';
-cLogInfo          = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pView:%pView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pSuppressZero:%pSuppressZero%, pSuppressConsol:%pSuppressConsol%, pSuppressRules:%pSuppressRules%, pZeroSource:%pZeroSource%, pCubeLogging:%pCubeLogging%, pTemp:%pTemp%, pFilePath:%pFilePath%, pFileName:%pFileName%, pDelim:%pDelim%, pQuote:%pQuote%, pTitleRecord:%pTitleRecord%, pSandbox:%pSandbox%, pSuppressConsolStrings:%pSuppressConsolStrings%.';
+cLogInfo          = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pView:%pView%, pFilter:%pFilter%, pFilterParallel:%pFilterParallel%, pParallelThreads:%pParallelThreads%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pSuppressZero:%pSuppressZero%, pSuppressConsol:%pSuppressConsol%, pSuppressRules:%pSuppressRules%, pZeroSource:%pZeroSource%, pCubeLogging:%pCubeLogging%, pTemp:%pTemp%, pFilePath:%pFilePath%, pFileName:%pFileName%, pDelim:%pDelim%, pQuote:%pQuote%, pTitleRecord:%pTitleRecord%, pSandbox:%pSandbox%, pSuppressConsolStrings:%pSuppressConsolStrings%  pIncludeDescendants %pIncludeDescendants%.';
 cDefaultView      = Expand( '%cThisProcName%_%cTimeStamp%_%cRandomInt%' );
 cLenASCIICode     = 3;
 
@@ -1191,6 +1195,7 @@ Else;
           'pSuppressConsol', pSuppressConsol,
           'pSuppressRules', pSuppressRules,
           'pSuppressConsolStrings', pSuppressConsolStrings,
+          'pIncludeDescendants',pIncludeDescendants,
           'pDimDelim', pDimDelim,
           'pEleStartDelim', pEleStartDelim,
           'pEleDelim', pEleDelim,
@@ -1338,7 +1343,7 @@ Else;
 EndIf ;
 
 ### End Epilog ###
-576,CubeAction=1511DataAction=1503CubeLogChanges=0
+576,CubeAction=1511DataAction=1503CubeLogChanges=0_ParameterConstraints=e30=
 930,0
 638,1
 804,0

--- a/main/}bedrock.cube.view.create.pro
+++ b/main/}bedrock.cube.view.create.pro
@@ -4,7 +4,7 @@
 586,
 585,
 564,
-565,"sboQr?V0M]Y7G;3H6mRaNI0LXAnSGJXIsHXxUJ]055OaeCMIxUbD7EZbZn:?s;Qk9;`@eHAq\xnUOibWWOyL][8cffmf_bQoMuIBsCd=52Bzyo2?syoytjViHC=L`\2en\L05lPb1@7@>5<]zLN;upadni>:Ifg<iPxo?V?o>nUVRt7lSaAQ8qzBePFzNNeOyFXJKbJ:"
+565,"jwKE7Ws86Ia\@zwiIdTCpAXNUBcijIBr1`r>CyLX6uRI;8gq@o3A]T1DjaICzuOuBqycUglRnWhF]XiUZR;FT:a\M5dGVd09Ppm_v;upr;[b7aRLWNpU5^Xpl_?=i<^paZDbpdz;gCf1bT2KWur<3Dy;EcVH2HD25L9QaR\1KSE;`PO3hr\na:oEe=:X5[SvKJYe=pA0"
 559,1
 928,0
 593,
@@ -25,7 +25,7 @@
 569,0
 592,0
 599,1000
-560,15
+560,16
 pLogOutput
 pStrictErrorHandling
 pCube
@@ -35,13 +35,14 @@ pSuppressZero
 pSuppressConsol
 pSuppressRules
 pSuppressConsolStrings
+pIncludeDescendants
 pDimDelim
 pEleStartDelim
 pEleDelim
 pTemp
 pSandBox
 pSubN
-561,15
+561,16
 1
 1
 2
@@ -51,13 +52,14 @@ pSubN
 1
 1
 1
+1
 2
 2
 2
 1
 2
 1
-590,15
+590,16
 pLogOutput,0
 pStrictErrorHandling,0
 pCube,""
@@ -67,13 +69,14 @@ pSuppressZero,1
 pSuppressConsol,1
 pSuppressRules,1
 pSuppressConsolStrings,-1
+pIncludeDescendants,0
 pDimDelim,"&"
 pEleStartDelim,"¦"
 pEleDelim,"+"
 pTemp,1
 pSandBox,""
 pSubN,0
-637,15
+637,16
 pLogOutput,"OPTIONAL: Write parameters and action summary to server message log (Boolean True = 1)"
 pStrictErrorHandling,"OPTIONAL: On encountering any error, exit with major error status by ProcessQuit after writing to the server message log (Boolean True = 1)"
 pCube,"REQUIRED: Cube Name"
@@ -83,6 +86,7 @@ pSuppressZero,"REQUIRED: Suppress Zero Data (Skip = 1)"
 pSuppressConsol,"REQUIRED: Suppress Consolidations (Skip = 1)"
 pSuppressRules,"REQUIRED: Suppress Rules (Skip = 1)"
 pSuppressConsolStrings,"REQUIRED: Suppress Strings on Consolidations (Skip = 1, Include = 0) (Default [Skip] = -1 for backward compatibility)"
+pIncludeDescendants,"OPTIONAL: Include all descendants when copying consolidated values"
 pDimDelim,"REQUIRED: Delimiter for start of Dimension/Element set"
 pEleStartDelim,"REQUIRED: Delimiter for start of element list"
 pEleDelim,"REQUIRED: Delimiter between elements"
@@ -103,7 +107,7 @@ If( 1 = 0 );
     ExecuteProcess( '}bedrock.cube.view.create', 'pLogOutput', pLogOutput,
       'pStrictErrorHandling', pStrictErrorHandling,
     	'pCube', '', 'pView', '', 'pFilter', '',
-    	'pSuppressZero', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressConsolStrings', 1,
+    	'pSuppressZero', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressConsolStrings', 1, 'pIncludeDescendants',0,
     	'pDimDelim', '&', 'pEleStartDelim', '¦', 'pEleDelim', '+',
     	'pTemp', 1,'pSandbox', pSandbox,'pSubN', 0
     );
@@ -156,7 +160,7 @@ cMsgErrorLevel    = 'ERROR';
 cMsgErrorContent  = 'User:%cUserName% Process:%cThisProcName% ErrorMsg:%sMessage%';
 cMsgInfoLevel     =  'INFO';
 cMsgInfoContent   = '%cThisProcName% : %sMessage% : %cUserName%';
-cLogInfo          = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pView:%pView%, pFilter:%pFilter%, pSuppressZero:%pSuppressZero%, pSuppressConsol:%pSuppressConsol%, pSuppressRules:%pSuppressRules%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pTemp:%pTemp%, pSandbox:%pSandbox%, pSuppressConsolStrings:%pSuppressConsolStrings%.' ;  
+cLogInfo          = 'Process:%cThisProcName% run with parameters pCube:%pCube%, pView:%pView%, pFilter:%pFilter%, pSuppressZero:%pSuppressZero%, pSuppressConsol:%pSuppressConsol%, pSuppressRules:%pSuppressRules%, pDimDelim:%pDimDelim%, pEleStartDelim:%pEleStartDelim%, pEleDelim:%pEleDelim%, pTemp:%pTemp%, pSandbox:%pSandbox%, pSuppressConsolStrings:%pSuppressConsolStrings%  pIncludeDescendants %pIncludeDescendants%.' ;  
 
 
 sSubset           = pView;
@@ -445,7 +449,7 @@ WHILE (nChar <= nCharCount);
           
           sElement = DimensionElementPrincipalName(sDimension,sElement);
 
-          If ( pSuppressConsol = 1 & DTYPE( sDimension, sElement) @= 'C'  );
+          If ( (pSuppressConsol = 1 % pIncludeDescendants=1) & DTYPE( sDimension, sElement) @= 'C'  );
               # Add all N level elements to the subset
               # Loop through all elements and check if it is an ancestor
               sMessage = 'Element ' | sElement | ' is consolidated' ;
@@ -603,7 +607,7 @@ Else;
 EndIf;
   
 ### End Epilog ###
-576,CubeAction=1511DataAction=1503CubeLogChanges=0
+576,CubeAction=1511DataAction=1503CubeLogChanges=0_ParameterConstraints=e30=
 930,0
 638,1
 804,0


### PR DESCRIPTION
pInlcudeDescendants will include all descendants for the consolidated elements passed in as a filter expression -- useful for copying string elements as they can be input on consolidated elements.
For example, for this example:
![image](https://github.com/cubewise-code/bedrock/assets/30726099/23023254-22f9-46b5-8a4a-039001916c6e)
running 
```
  ExecuteProcess( '}bedrock.cube.data.copy'
        , 'pLogOutput', 1
        ,'pStrictErrorHandling', 1
        ,'pCube', 'test'
        , 'pSrcView', ''
        , 'pTgtView', ''
        , 'pFilter', 'dim1¦Total'
        ,'pFilterParallel', ''
        , 'pParallelThreads', 0
        ,'pEleMapping', 'dim2¦ version1-> version2'
        , 'pMappingDelim', '->'
        ,'pDimDelim', '&'
        , 'pEleStartDelim', '¦'
        , 'pEleDelim', '+'
        ,'pFactor', 1
        , 'pSuppressConsol', 0
        ,'pSuppressConsolStrings', 0
        , 'pSuppressRules', 0
        , 'pSuppressZero', 1
        , 'pCumulate', 0
        ,'pZeroTarget', 1
        ,'pZeroSource', 0
        ,'pTemp', 1
        , 'pCubeLogging', 0
        , 'pSandbox', ''
        , 'pFile', 1
        , 'pSubN', 0
    );
```
will copy only string on `Total` element:
![image](https://github.com/cubewise-code/bedrock/assets/30726099/254db8fe-7a22-458e-9ee4-88f9d7a00a43)
running 
``` ExecuteProcess( '}bedrock.cube.data.copy'
        , 'pLogOutput', 1
        ,'pStrictErrorHandling', 1
        ,'pCube', 'test'
        , 'pSrcView', ''
        , 'pTgtView', ''
        , 'pFilter', 'dim1¦Total'
        ,'pFilterParallel', ''
        , 'pParallelThreads', 0
        ,'pEleMapping', 'dim2¦ version1-> version2'
        , 'pMappingDelim', '->'
        ,'pDimDelim', '&'
        , 'pEleStartDelim', '¦'
        , 'pEleDelim', '+'
        ,'pFactor', 1
        , 'pSuppressConsol', 0
        ,'pSuppressConsolStrings', 0
        , 'pSuppressRules', 0
        , 'pSuppressZero', 1
        ,'pIncludeDescendants',1
        , 'pCumulate', 0
        ,'pZeroTarget', 1
        ,'pZeroSource', 0
        ,'pTemp', 1
        , 'pCubeLogging', 0
        , 'pSandbox', ''
        , 'pFile', 1
        , 'pSubN', 0
    );
```
will copy all child elements as well:
![image](https://github.com/cubewise-code/bedrock/assets/30726099/d099d303-2468-48de-a1cc-8e36cfb63965)

