### PR TITLE
Update }bedrock.cube.data.export.pro

### DIFF
--- a/main/}bedrock.cube.data.export.pro
+++ b/main/}bedrock.cube.data.export.pro
@@ -758,7 +758,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,489
+572,491
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1186,6 +1186,7 @@ Else;
   ENDIF;
 
   # Create Processing View for source version
+  If( ViewExists( pCube, cView ) = 0 );
   nRet = ExecuteProcess('}bedrock.cube.view.create',
           'pLogOutput', pLogOutput,
           'pStrictErrorHandling', pStrictErrorHandling,
@@ -1203,6 +1204,7 @@ Else;
           'pTemp', pTemp,
           'pSubN', pSubN
           );
+    EndIf;
 
     # Validate Sandbox
     If( TRIM( pSandbox ) @<> '' );


### PR DESCRIPTION
Existing public views should not be recreated. The use case is that views already exist (typically with filters applied) and then a simple call to '}bedrock.cube.data.export' with the name of the view and pFilter = '' would reset the view and remove the filters. That reset is done in '}bedrock.cube.view.create' but probably best to not break into that process.