### PR TITLE
pSandbox parameter not passed towards }bedrock.cube.view.create

### DIFF
--- a/main/}bedrock.cube.data.clear.pro
+++ b/main/}bedrock.cube.data.clear.pro
@@ -379,7 +379,7 @@ While( nCubeDelimiterIndex <> 0 );
                     'pCube', sCube, 'pView', cView, 'pFilter', pFilter,
                     'pSuppressZero', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressConsolStrings', pSuppressConsolStrings,
                     'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim, 'pEleDelim', pEleDelim,
-                    'pTemp', pTemp, 'pSubN', pSubN
+                    'pTemp', pTemp, 'pSandbox', pSandbox, 'pSubN', pSubN
                    );
 
               # Validate Sandbox
@@ -548,7 +548,7 @@ While( nCubeDelimiterIndex <> 0 );
                   'pCube', sCube, 'pView', cView, 'pFilter', pFilter,
                   'pSuppressZero', 1, 'pSuppressConsol', 1, 'pSuppressRules', 1, 'pSuppressConsolStrings', pSuppressConsolStrings,
                   'pDimDelim', pDimDelim, 'pEleStartDelim', pEleStartDelim, 'pEleDelim', pEleDelim,
-                  'pTemp', pTemp, 'pSubN', pSubN
+                  'pTemp', pTemp, 'pSandbox', pSandbox, 'pSubN', pSubN
                   );
                   
               # Validate Sandbox

--- a/main/}bedrock.cube.data.copy.intercube.pro
+++ b/main/}bedrock.cube.data.copy.intercube.pro
@@ -322,7 +322,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,1490
+572,1492
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1664,8 +1664,9 @@ Else;
           'pSuppressConsolStrings', pSuppressConsolStrings, 
           'pDimDelim', pDimDelim,
           'pEleStartDelim', pEleStartDelim,
-          'pEleDelim', pEleDelim ,
-          'pTemp', pTemp
+          'pEleDelim', pEleDelim,
+          'pTemp', pTemp,
+          'pSandbox', pSandbox
           );
   
       IF(nRet <> 0);
@@ -1726,8 +1727,9 @@ Else;
       'pSuppressConsolStrings', pSuppressConsolStrings, 
       'pDimDelim', pDimDelim,
       'pEleStartDelim', pEleStartDelim,
-      'pEleDelim', pEleDelim ,
+      'pEleDelim', pEleDelim,
       'pTemp', pTemp,
+      'pSandbox', pSandbox,
       'pSubN', pSubN
       );
     

--- a/main/}bedrock.cube.data.copy.pro
+++ b/main/}bedrock.cube.data.copy.pro
@@ -486,7 +486,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=33ColType=827
 603,0
-572,1044
+572,1045
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1441,8 +1441,9 @@ Else;
       'pIncludeDescendants',pIncludeDescendants,
       'pDimDelim', pDimDelim,
       'pEleStartDelim', pEleStartDelim,
-      'pEleDelim', pEleDelim ,
+      'pEleDelim', pEleDelim,
       'pTemp', pTemp,
+      'pSandbox', pSandbox,
       'pSubN', pSubN
       );
 

--- a/main/}bedrock.cube.data.export.pro
+++ b/main/}bedrock.cube.data.export.pro
@@ -758,7 +758,7 @@ VarType=32ColType=827
 VarType=32ColType=827
 VarType=32ColType=827
 603,0
-572,489
+572,490
 #Region CallThisProcess
 # A snippet of code provided as an example how to call this process should the developer be working on a system without access to an editor with auto-complete.
 If( 1 = 0 );
@@ -1201,6 +1201,7 @@ Else;
           'pEleStartDelim', pEleStartDelim,
           'pEleDelim', pEleDelim,
           'pTemp', pTemp,
+          'pSandbox', pSandbox,
           'pSubN', pSubN
           );
 


### PR DESCRIPTION
The parameter pSandbox was not passed to the called process(es). This leads to the sandbox setting in the calling processes being ignored.