### PR TITLE
Update }bedrock.hier.sub.delete.pro

### DIFF
--- a/main/}bedrock.hier.sub.delete.pro
+++ b/main/}bedrock.hier.sub.delete.pro
@@ -239,7 +239,7 @@ If ( SCAN( cCharAny, pDim ) = 0 & SCAN( cStringAny, pDim ) = 0 & SCAN( pDelim, p
         ProcessBreak;
     EndIf;
   EndIf;
-  If ( HierarchySubsetExists( pDim, pHier, pSub ) = 0 );
+  If (  pHier @<> '' & HierarchySubsetExists( pDim, pHier, pSub ) = 0 );
     nErrors = 1;
     sMessage = Expand( 'Subset %pSub% doesn''t exist in hierarchy %pHier% of dimension %pDim%.' );
     LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );


### PR DESCRIPTION
pHier can still be empty at this point. Checking if the subset exists with the hierarchy being empty evaluates as 0, even if the subset does exist in the dimension.

Alternatively, the overwrite of pHier with pDim in case pHier = '' could be moved up in the code.

If ( pHier @= '' );
    pHier = pDim;
  EndIf;