### PR TITLE
Bug Fix. }bedrock.hier.unwind does nothing (and does not error) under certain parameters

### DIFF
--- a/main/}bedrock.hier.unwind.pro
+++ b/main/}bedrock.hier.unwind.pro
@@ -141,6 +141,11 @@ ENDIF;
 ### Validate Parameters ###
 nErrors = 0;
 
+# If blank delimiter specified then convert to default
+If( pDelim @= '' );
+    pDelim = '&';
+EndIf;
+
 If( Scan( '*', pDim ) = 0 & Scan( '?', pDim ) = 0 & Scan( pDelim, pDim ) = 0 & Scan( ':', pDim ) > 0 & pHier @= '' );
     # A hierarchy has been passed as dimension. Handle the input error by splitting dim:hier into dimension & hierarchy
     pHier       = SubSt( pDim, Scan( ':', pDim ) + 1, Long( pDim ) );
@@ -191,11 +196,6 @@ ElseIf( Trim( pConsol ) @= '' );
     sMessage = 'No consolidated element specified.';
     LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
 Endif;
-
-# If blank delimiter specified then convert to default
-If( pDelim @= '' );
-    pDelim = '&';
-EndIf;
 
 ### Check for errors before continuing
 If( nErrors <> 0 );


### PR DESCRIPTION
Bug Fix. }bedrock.hier.unwind does nothing (and does not error) under certain parameters
if pDelim = '' and pHier = '' and pDim is one dimension (no delimiter or wildcard characters and does not specify a hierarchy with ':') and pConsol is '*',
then all the places pHier gets defined will be false.
Line 71 is false because there is no ':' in pDim
Line 89 is false because SCAN( '', pDim ) = 1

This leads to line 140 being false, and line 193 being true.
In the line 193 IF block, pHier has not been redefined to anything. Therefore the HierarchyElementDelete and HierarchyElementInsert statements on line 206 and 207 fail because pHier is still ''

Redefining pHier is done in the block following 193, that starts at line 216

# Solution
By moving the redefining of pDelim to the beginning, SCAN( '', pDim ) will be 0 instead of 1, which will make line 89 true which will define pHier.